### PR TITLE
Handle assets without a thumbnail / thumb hash

### DIFF
--- a/ImmichFrame/Helpers/AssetHelper.cs
+++ b/ImmichFrame/Helpers/AssetHelper.cs
@@ -59,8 +59,8 @@ namespace ImmichFrame.Helpers
             }
 
             if (assetsAdded)
-                // return only unique assets, no duplicates
-                return list.DistinctBy(x => x.Id).ToDictionary(x => Guid.Parse(x.Id));
+                // return only unique assets, no duplicates, only with Thumbnail
+                return list.Where(x => x.Thumbhash != null).DistinctBy(x => x.Id).ToDictionary(x => Guid.Parse(x.Id));
 
             return null;
         }
@@ -184,6 +184,12 @@ namespace ImmichFrame.Helpers
 
                     if (randomAssets.Any())
                     {
+                        var asset = randomAssets.First();
+
+                        // do not return with no thumbnail
+                        if (asset.Thumbhash == null)
+                            return await GetRandomAsset();
+
                         return randomAssets.First();
                     }
                 }

--- a/ImmichFrame/Models/AssetResponseDto.cs
+++ b/ImmichFrame/Models/AssetResponseDto.cs
@@ -31,10 +31,13 @@ public partial class AssetResponseDto
     }
 
     [JsonIgnore]
-    public Stream ThumbhashImage => GetThumbHashStream();
+    public Stream? ThumbhashImage => GetThumbHashStream();
 
-    private Stream GetThumbHashStream()
+    private Stream? GetThumbHashStream()
     {
+        if (this.Thumbhash == null)
+            return null;
+
         var hash = Convert.FromBase64String(this.Thumbhash);
         var thumbhash = new ThumbHash(hash);
         return ImageHelper.SaveDataUrlToStream(thumbhash.ToDataUrl());
@@ -46,7 +49,7 @@ public partial class AssetResponseDto
     private async Task<Stream> ServeImage()
     {
         string localPath;
-        if(PlatformDetector.IsDesktop())
+        if (PlatformDetector.IsDesktop())
         {
             localPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Immich_Assets", $"{Id}.{ThumbnailFormat.JPEG}");
         }

--- a/ImmichFrame/ViewModels/MainViewModel.cs
+++ b/ImmichFrame/ViewModels/MainViewModel.cs
@@ -23,6 +23,9 @@ public partial class MainViewModel : NavigatableViewModelBase
     }
     public async Task SetImage(AssetResponseDto asset)
     {
+        if (asset.ThumbhashImage == null)
+            return;
+
         using (Stream tmbStream = asset.ThumbhashImage)
         using (Stream imgStream = await asset.AssetImage)
         {


### PR DESCRIPTION
Some images (mostly live photos/generated videos) do not have thumbnails. ImmichFrame displays thumbnails. This handles this and skips the asset.

Fixes #53