### PR TITLE
Convert to Generated Regex, remove \d usage

### DIFF
--- a/ImmichFrame/Helpers/ImageHelper.cs
+++ b/ImmichFrame/Helpers/ImageHelper.cs
@@ -1,24 +1,20 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace ImmichFrame.Helpers
 {
-    public static class ImageHelper
+    public static partial class ImageHelper
     {
+        [GeneratedRegex(@"^data:((?<type>[\w\/]+))?;base64,(?<data>.+)$")]
+        private static partial Regex DataRegex();
+        
         public static Stream SaveDataUrlToStream(string dataUrl)
         {
-            var matchGroups = Regex.Match(dataUrl, @"^data:((?<type>[\w\/]+))?;base64,(?<data>.+)$").Groups;
-            var base64Data = matchGroups["data"].Value;
+            var base64Data = DataRegex().Match(dataUrl).Groups["data"].Value;
             var binData = Convert.FromBase64String(base64Data);
 
-            var ms = new MemoryStream(binData);
-
-            return ms;
+            return new MemoryStream(binData);
         }
     }
 }

--- a/ImmichFrame/Models/Settings.cs
+++ b/ImmichFrame/Models/Settings.cs
@@ -15,13 +15,13 @@ namespace ImmichFrame.Models;
 
 public partial class Settings
 {
-    [GeneratedRegex(@"^((\d+)||(\d+\,\d+)||(\d+\,\d+\,\d+\,\d+))$")]
+    [GeneratedRegex(@"^(([0-9]+)||([0-9]+\,[0-9]+)||([0-9]+\,[0-9]+\,[0-9]+\,[0-9]+))$")]
     private static partial Regex MarginRegex();
 
     [GeneratedRegex(@"^(?i)(metric|imperial)$")]
     private static partial Regex UnitRegex();
 
-    [GeneratedRegex(@"^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$")]
+    [GeneratedRegex(@"^(-?[0-9]+(\.[0-9]+)?),\s*(-?[0-9]+(\.[0-9]+)?)$")]
     private static partial Regex LatLongRegex();
 
     [GeneratedRegex(@"^#(?:[0-9a-fA-F]{3}){1,2}$")]

--- a/ImmichFrame/Models/Settings.cs
+++ b/ImmichFrame/Models/Settings.cs
@@ -13,8 +13,20 @@ using System.Xml.Linq;
 namespace ImmichFrame.Models;
 
 
-public class Settings
+public partial class Settings
 {
+    [GeneratedRegex(@"^((\d+)||(\d+\,\d+)||(\d+\,\d+\,\d+\,\d+))$")]
+    private static partial Regex MarginRegex();
+
+    [GeneratedRegex(@"^(?i)(metric|imperial)$")]
+    private static partial Regex UnitRegex();
+
+    [GeneratedRegex(@"^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$")]
+    private static partial Regex LatLongRegex();
+
+    [GeneratedRegex(@"^#(?:[0-9a-fA-F]{3}){1,2}$")]
+    private static partial Regex HexColorRegex();
+    
     public string ImmichServerUrl { get; set; } = string.Empty;
     public string ApiKey { get; set; } = string.Empty;
     public string Margin { get; set; } = "0,0,0,0";
@@ -228,7 +240,7 @@ public class Settings
                     break;
                 case "Margin":
                     var margin = value.ToString()!;
-                    if (!Regex.IsMatch(margin, @"^((\d+)||(\d+\,\d+)||(\d+\,\d+\,\d+\,\d+))$"))
+                    if (!MarginRegex().IsMatch(margin))
                     {
                         throw new SettingsNotValidException($"Value of '{SettingsValue.Key}' is not valid. (' {value} ')");
                     }
@@ -284,20 +296,20 @@ public class Settings
                     property.SetValue(settings, value);
                     break;
                 case "UnitSystem":
-                    if (!Regex.IsMatch(value.ToString()!, @"^(?i)(metric|imperial)$"))
+                    if (!UnitRegex().IsMatch(value.ToString()!))
                         throw new SettingsNotValidException($"Value of '{SettingsValue.Key}' is not valid. ('{value}')");
                     value = value.ToString()!.ToLower() == "metric" ? OpenWeatherMap.UnitSystem.Metric : OpenWeatherMap.UnitSystem.Imperial;
                     property.SetValue(settings, value);
                     break;
                 case "WeatherLatLong":
                     // Regex match Lat/Lon
-                    if (!Regex.IsMatch(value.ToString()!, @"^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$"))
+                    if (!LatLongRegex().IsMatch(value.ToString()!))
                         throw new SettingsNotValidException($"Value of '{SettingsValue.Key}' is not valid. ('{value}')");
                     property.SetValue(settings, value);
                     break;
                 case "FontColor":
                     // Regex match Hex color
-                    if (!Regex.IsMatch(value.ToString()!, @"^#(?:[0-9a-fA-F]{3}){1,2}$"))
+                    if (!HexColorRegex().IsMatch(value.ToString()!))
                         throw new SettingsNotValidException($"Value of '{SettingsValue.Key}' is not valid. ('{value}')");
                     property.SetValue(settings, value);
                     break;


### PR DESCRIPTION
Generated Regex: https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators

From https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#decimal-digit-character-d

> \d matches any decimal digit. It is equivalent to the \p{Nd} regular expression pattern, which includes the standard decimal digits 0-9 as well as the decimal digits of a number of other character sets.