### PR TITLE
Reverting version of Microsoft.Extensions.ApiDescription.Client and NSwag.ApiDescription.Client packages.

### DIFF
--- a/ImmichFrame/ImmichFrame.csproj
+++ b/ImmichFrame/ImmichFrame.csproj
@@ -40,7 +40,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NSwag.ApiDescription.Client" Version="14.1.0">
+    <PackageReference Include="NSwag.ApiDescription.Client" Version="13.18.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The update to this package from 1382fdbd8e91185a7f01fe6b7fd26b73eebf2cd8 was causing an issue with URLs not being assembled correctly.