### PR TITLE
feat: Adding UnattendedMode setting to enable auto-continue on ErrorView.

### DIFF
--- a/ImmichFrame/Models/Settings.cs
+++ b/ImmichFrame/Models/Settings.cs
@@ -66,6 +66,7 @@ namespace ImmichFrame.Models
         [JsonIgnore]
         public float WeatherLong => !string.IsNullOrWhiteSpace(WeatherLatLong) ? float.Parse(WeatherLatLong!.Split(',')[1]) : 0f;
         public string Language { get; set; } = "en";
+        public bool UnattendedMode { get; set; } = false;
         //public static string JsonSettingsPath => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.json");
         public static string JsonSettingsPath
         {
@@ -178,7 +179,7 @@ namespace ImmichFrame.Models
                             throw new SettingsNotValidException($"Value of '{SettingsValue.Key}' is not a valid URL: '{url}'");
                         }
                         property.SetValue(settings, url);
-                        break;                        
+                        break;
                     case "Margin":
                         var margin = value.ToString()!;
                         if (!MarginRegex().IsMatch(margin))
@@ -233,6 +234,7 @@ namespace ImmichFrame.Models
                     case "ShowImageDesc":
                     case "ShowImageLocation":
                     case "ShowWeatherDescription":
+                    case "UnattendedMode":
                         if (!bool.TryParse(value.ToString(), out var boolValue))
                             throw new SettingsNotValidException($"Value of '{SettingsValue.Key}' is not valid. ('{value}')");
                         property.SetValue(settings, boolValue);
@@ -328,7 +330,8 @@ namespace ImmichFrame.Models
                 WeatherFontSize = 36,
                 UnitSystem = "imperial",
                 WeatherLatLong = "40.7128,74.0060",
-                Language = "en"
+                Language = "en",
+                UnattendedMode = false
             };
             string json = JsonSerializer.Serialize(defaultSettings, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(JsonSettingsPath, json);

--- a/ImmichFrame/ViewModels/MainViewModel.cs
+++ b/ImmichFrame/ViewModels/MainViewModel.cs
@@ -178,6 +178,11 @@ public partial class MainViewModel : NavigatableViewModelBase
                 attempt++;
                 if (attempt >= 3)
                 {
+                    if (Settings.UnattendedMode)
+                    {
+                        // Do not show message and break the loop
+                        break;
+                    }
                     this.Navigate(new ErrorViewModel(ex));
                 }
             }


### PR DESCRIPTION
I'm making some of my family digital photo frames and need them to be as hands-off as possible since most of them are not very tech-savy.
This mode allows me to silently handle issues such as the Immich server going down (which causes an exception on 404s) and other spurious exceptions without having to get a call from them :)
Figured this will probably be helpful for others as well.