### PR TITLE
State display & ISO 3166 Abbreviations

### DIFF
--- a/ImmichFrame/Helpers/LocationHelper.cs
+++ b/ImmichFrame/Helpers/LocationHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using ImmichFrame.Models;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -29,11 +30,20 @@ namespace ImmichFrame.Helpers
 
         public static string GetLocationString(ImmichFrame.Models.ExifResponseDto exifInfo)
         {
-            string country = GetCountryCode(exifInfo.Country);
-            string state = exifInfo.State?.Split(", ").Last() ?? string.Empty;
+            var settings = Settings.CurrentSettings;
+
+            string country = settings.ShowCountry ? exifInfo.Country : string.Empty;
+            if (settings.AbbreviateCountry)
+            {
+                country = GetCountryCode(country);
+            }
+
+            string state = settings.ShowState ? exifInfo.State?.Split(", ").Last() ?? string.Empty : string.Empty;
+
+            string city = settings.ShowCity ? exifInfo.City : string.Empty;
 
             var locationData = new[] {
-                    exifInfo.City,
+                    city,
                     state,
                     country
                 }.Where(x => !string.IsNullOrWhiteSpace(x));

--- a/ImmichFrame/Helpers/LocationHelper.cs
+++ b/ImmichFrame/Helpers/LocationHelper.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace ImmichFrame.Helpers
+{
+    public class LocationHelper
+    {
+        static List<RegionInfo> countries_info = new List<RegionInfo>();
+
+        static LocationHelper()
+        {
+            foreach (CultureInfo culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+            {
+                countries_info.Add(new RegionInfo(culture.TextInfo.CultureName));
+            }
+        }
+
+        public static string GetCountryCode(string country)
+        {
+            string target_country = country;
+            if (country == "United States of America")
+            {
+                target_country = "United States";
+            }
+            RegionInfo? country_info = countries_info.Where(info => info.EnglishName == target_country).FirstOrDefault();
+            return country_info?.ThreeLetterISORegionName ?? country;
+        }
+
+        public static string GetLocationString(ImmichFrame.Models.ExifResponseDto exifInfo)
+        {
+            string country = GetCountryCode(exifInfo.Country);
+            string state = exifInfo.State?.Split(", ").Last() ?? string.Empty;
+
+            var locationData = new[] {
+                    exifInfo.City,
+                    state,
+                    country
+                }.Where(x => !string.IsNullOrWhiteSpace(x));
+            return string.Join(", ", locationData);
+        }
+    }
+}

--- a/ImmichFrame/Models/Settings.cs
+++ b/ImmichFrame/Models/Settings.cs
@@ -53,6 +53,10 @@ namespace ImmichFrame.Models
         public bool ShowImageDesc { get; set; } = true;
         public int ImageDescFontSize { get; set; } = 36;
         public bool ShowImageLocation { get; set; } = true;
+        public bool ShowCity { get; set; } = true;
+        public bool ShowState { get; set; } = true;
+        public bool ShowCountry { get; set; } = true;
+        public bool AbbreviateCountry { get; set; } = true;
         public int ImageLocationFontSize { get; set; } = 36;
         public string FontColor { get; set; } = "#FFFFFF";
         public string? WeatherApiKey { get; set; } = string.Empty;
@@ -235,6 +239,10 @@ namespace ImmichFrame.Models
                     case "ShowPhotoDate":
                     case "ShowImageDesc":
                     case "ShowImageLocation":
+                    case "ShowCity":
+                    case "ShowState":
+                    case "ShowCountry":
+                    case "AbbreviateCountry":
                     case "ShowWeatherDescription":
                     case "UnattendedMode":
                         if (!bool.TryParse(value.ToString(), out var boolValue))
@@ -326,6 +334,10 @@ namespace ImmichFrame.Models
                 ShowImageDesc = true,
                 ImageDescFontSize = 36,
                 ShowImageLocation = true,
+                ShowCity = true,
+                ShowState = true,
+                ShowCountry = true,
+                AbbreviateCountry = true,
                 ImageLocationFontSize = 36,
                 FontColor = "#FFFFFF",
                 WeatherApiKey = "",

--- a/ImmichFrame/ViewModels/MainViewModel.cs
+++ b/ImmichFrame/ViewModels/MainViewModel.cs
@@ -102,12 +102,7 @@ public partial class MainViewModel : NavigatableViewModelBase
 
             if (asset?.ExifInfo != null)
             {
-                var locationData = new[] {
-                    asset.ExifInfo.City,
-                    asset.ExifInfo.Country
-                }.Where(x => !string.IsNullOrWhiteSpace(x));
-
-                ImageLocation = string.Join(", ", locationData);
+                ImageLocation = LocationHelper.GetLocationString(asset.ExifInfo);
             }
             else
             {

--- a/ImmichFrame/Views/SettingsView.axaml
+++ b/ImmichFrame/Views/SettingsView.axaml
@@ -200,40 +200,56 @@
 					<CheckBox IsChecked="{Binding Settings.ShowImageLocation}" TabIndex="27"/>
 				</StackPanel>
 				<StackPanel>
+					<TextBlock Text="ShowCity"/>
+					<CheckBox IsChecked="{Binding Settings.ShowCity}" TabIndex="28"/>
+				</StackPanel>
+				<StackPanel>
+					<TextBlock Text="ShowState"/>
+					<CheckBox IsChecked="{Binding Settings.ShowState}" TabIndex="29"/>
+				</StackPanel>
+				<StackPanel>
+					<TextBlock Text="ShowCountry"/>
+					<CheckBox IsChecked="{Binding Settings.ShowCountry}" TabIndex="30"/>
+				</StackPanel>
+				<StackPanel>
+					<TextBlock Text="AbbreviateCountry"/>
+					<CheckBox IsChecked="{Binding Settings.AbbreviateCountry}" TabIndex="31"/>
+				</StackPanel>
+				<StackPanel>
 					<TextBlock Text="ImageLocationFontSize"/>
-					<NumericUpDown Value="{Binding Settings.ImageLocationFontSize}" KeyDown="NumericUpDown_KeyDown" TabIndex="28"/>
+					<NumericUpDown Value="{Binding Settings.ImageLocationFontSize}" KeyDown="NumericUpDown_KeyDown" TabIndex="32"/>
 				</StackPanel>
 				<StackPanel>
 					<TextBlock Text="FontColor"/>
-					<TextBox Text="{Binding Settings.FontColor}" TabIndex="29"/>
+					<TextBox Text="{Binding Settings.FontColor}" TabIndex="33"/>
 				</StackPanel>
 				<StackPanel>
 					<HyperlinkButton Content="WeatherApiKey" NavigateUri="https://openweathermap.org/appid" />
-					<TextBox Text="{Binding Settings.WeatherApiKey}" Watermark="Click WeatherApiKey learn more" TabIndex="30"/>
+					<TextBox Text="{Binding Settings.WeatherApiKey}" Watermark="Click WeatherApiKey learn more" TabIndex="34"/>
 				</StackPanel>
 				<StackPanel>
 					<TextBlock Text="ShowWeatherDescription"/>
-					<CheckBox IsChecked="{Binding Settings.ShowWeatherDescription}" TabIndex="31"/>
+					<CheckBox IsChecked="{Binding Settings.ShowWeatherDescription}" TabIndex="35"/>
 				</StackPanel>
 				<StackPanel>
 					<TextBlock Text="WeatherFontSize"/>
-					<NumericUpDown Value="{Binding Settings.WeatherFontSize}" KeyDown="NumericUpDown_KeyDown" TabIndex="32"/>
+					<NumericUpDown Value="{Binding Settings.WeatherFontSize}" KeyDown="NumericUpDown_KeyDown" TabIndex="36"/>
 				</StackPanel>
 				<StackPanel>
 					<TextBlock Text="UnitSystem"/>
-					<TextBox Text="{Binding Settings.UnitSystem}" TabIndex="33"/>
+					<TextBox Text="{Binding Settings.UnitSystem}" TabIndex="37"/>
 				</StackPanel>
 				<StackPanel>
 					<TextBlock Text="WeatherLatLong"/>
-					<TextBox Text="{Binding Settings.WeatherLatLong}" TabIndex="34"/>
+					<TextBox Text="{Binding Settings.WeatherLatLong}" TabIndex="38"/>
 				</StackPanel>
 				<StackPanel>
 					<TextBlock Text="Language"/>
-					<TextBox Text="{Binding Settings.Language}" TabIndex="35"/>
+					<TextBox Text="{Binding Settings.Language}" TabIndex="39"/>
 				</StackPanel>
         <StackPanel>
           <TextBlock Text="UnattendedMode"/>
-          <CheckBox IsChecked="{Binding Settings.UnattendedMode}" TabIndex="36"/>
+          <CheckBox IsChecked="{Binding Settings.UnattendedMode}" TabIndex="40"/>
         </StackPanel>
 				<Rectangle Height="600" Fill="Transparent" />
 			</StackPanel>


### PR DESCRIPTION
Adding State to location display and abbreviating State & Country displays (state only applies to USA & CAN states currently).

The existing display of <City, Country> was ambiguous to me (we Americans love reusing City names in every state :) ), so this change aims to allow including State while also allowing State and Country to be abbreviated to ISO 3166 values.

@JW-CH would love your input on this to make sure I'm not coming at this with too much of a USA/Canada focus. I've only added State-abbreviation logic for those two countries and my understanding is that the only EU state that has "states" is Germany, and I believe all of the other EU states will simply not show any field for "State" as was the case before (and Germany will display a non-abbreviated state currently).
@3rob3 I'm not sure what part of the world you're at, but your input is always welcome as well!