### PR TITLE
Show settings page instead of error message when settings not found.

### DIFF
--- a/ImmichFrame.Android/ImmichFrame.Android.csproj
+++ b/ImmichFrame.Android/ImmichFrame.Android.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>  
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Android" Version="11.1.2" />
+    <PackageReference Include="Avalonia.Android" Version="11.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ImmichFrame.Android/MainActivity.cs
+++ b/ImmichFrame.Android/MainActivity.cs
@@ -4,7 +4,6 @@ using Android.OS;
 using Android.Views;
 using Avalonia;
 using Avalonia.Android;
-using ImmichFrame.ViewModels;
 
 namespace ImmichFrame.Android;
 

--- a/ImmichFrame.Desktop/ImmichFrame.Desktop.csproj
+++ b/ImmichFrame.Desktop/ImmichFrame.Desktop.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ImmichFrame/ImmichFrame.csproj
+++ b/ImmichFrame/ImmichFrame.csproj
@@ -28,14 +28,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.2" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.2" />
+    <PackageReference Include="Avalonia" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.2" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="8.0.7">
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ImmichFrame/ViewModels/MainWindowViewModel.cs
+++ b/ImmichFrame/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using ImmichFrame.Exceptions;
 using ImmichFrame.Models;
+using System.IO;
 
 namespace ImmichFrame.ViewModels
 {
@@ -14,11 +15,18 @@ namespace ImmichFrame.ViewModels
         {
             try
             {
-                var settings = Settings.CurrentSettings;
+                if (!File.Exists(Settings.JsonSettingsPath))
+                {
+                    ContentViewModel = new SettingsViewModel(false);
+                }
+                else
+                {
+                    var settings = Settings.CurrentSettings;
 
-                Margin = Thickness.Parse(settings.Margin);
+                    Margin = Thickness.Parse(settings.Margin);
 
-                ContentViewModel = new MainViewModel();
+                    ContentViewModel = new MainViewModel();
+                }
             }
             catch (SettingsNotValidException ex)
             {

--- a/ImmichFrame/ViewModels/SettingsViewModel.cs
+++ b/ImmichFrame/ViewModels/SettingsViewModel.cs
@@ -26,6 +26,9 @@ namespace ImmichFrame.ViewModels
         private ObservableCollection<ListItem> excludedAlbumList;
 
         [ObservableProperty]
+        private bool cancelVisible = true;
+
+        [ObservableProperty]
         public Settings settings;
         public ICommand SaveCommand { get; set; }
         public ICommand CancelCommand { get; set; }
@@ -42,7 +45,9 @@ namespace ImmichFrame.ViewModels
         public List<string> StretchOptions { get; } = Enum.GetNames(typeof(Stretch)).ToList();
         public List<string> ImageLocationOptions { get; } = new List<string> { "City", "City,State", "City,State,Country" };
 
-        public SettingsViewModel()
+        // Parameterless constructor for XAML and design-time support
+        public SettingsViewModel() : this(true) {}
+        public SettingsViewModel(bool cancleEnabled = true)
         {
             try
             {
@@ -69,6 +74,7 @@ namespace ImmichFrame.ViewModels
             PeopleList = new ObservableCollection<ListItem>(Settings.People.Select(x => new ListItem(x.ToString())));
             AlbumList = new ObservableCollection<ListItem>(Settings.Albums.Select(x => new ListItem(x.ToString())));
             ExcludedAlbumList = new ObservableCollection<ListItem>(Settings.ExcludedAlbums.Select(x => new ListItem(x.ToString())));
+            CancelVisible = cancleEnabled;
         }
 
         private void TestMarginAction()

--- a/ImmichFrame/Views/ErrorView.axaml.cs
+++ b/ImmichFrame/Views/ErrorView.axaml.cs
@@ -1,7 +1,4 @@
-﻿using Avalonia.Input;
-using Avalonia.Threading;
-
-namespace ImmichFrame.Views;
+﻿namespace ImmichFrame.Views;
 
 public partial class ErrorView : BaseView
 {

--- a/ImmichFrame/Views/SettingsView.axaml
+++ b/ImmichFrame/Views/SettingsView.axaml
@@ -189,6 +189,7 @@
       </Expander>
       <UniformGrid Columns="3" Margin="0,10" >
         <Button Content="Cancel"
+            IsVisible="{Binding CancelVisible}"
             HorizontalAlignment="Stretch"
             Command="{Binding CancelCommand}"
             HorizontalContentAlignment="Center"/>


### PR DESCRIPTION
This is a minimal implementation to just show settings screen (instead of error message/exception) if settings.json is not found. The Welcome Page PR will more fully implement this, but I just wanted to add it now in case there is a release before Welcome Page is done. Most of the code was lifted straight from your draft PR for WelcomePage :), so it should be straightforward to merge once that is ready.

Other changes were updating Avalonia, and removing unused Usings.

Closes #104 