### PR TITLE
Directly use Settings.CurrentSettings

### DIFF
--- a/ImmichFrame/Helpers/AssetHelper.cs
+++ b/ImmichFrame/Helpers/AssetHelper.cs
@@ -42,9 +42,8 @@ namespace ImmichFrame.Helpers
         {
             using (var client = new HttpClient())
             {
-                var settings = Settings.CurrentSettings;
-                client.UseApiKey(settings.ApiKey);
-                var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+                client.UseApiKey(Settings.CurrentSettings.ApiKey);
+                var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
                 var itemsToAdd = new BulkIdsDto();
                 itemsToAdd.Ids.Add(new Guid(assetToAdd.Id));
                 await immichApi.AddAssetsToAlbumAsync(new Guid(immichFrameAlbum.Id), null, itemsToAdd);
@@ -64,18 +63,17 @@ namespace ImmichFrame.Helpers
         {
             using (var client = new HttpClient())
             {
-                var settings = Settings.CurrentSettings;
-                client.UseApiKey(settings.ApiKey);
-                var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+                client.UseApiKey(Settings.CurrentSettings.ApiKey);
+                var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
                 var immichAlbums = await immichApi.GetAllAlbumsAsync(null, null);
-                immichFrameAlbum = immichAlbums.FirstOrDefault(album => album.AlbumName == settings.ImmichFrameAlbumName)!;
+                immichFrameAlbum = immichAlbums.FirstOrDefault(album => album.AlbumName == Settings.CurrentSettings.ImmichFrameAlbumName)!;
                 if (immichFrameAlbum != null)
                 {
                     await immichApi.DeleteAlbumAsync(new Guid(immichFrameAlbum.Id));
                 }
                 var albumDto = new CreateAlbumDto
                 {
-                    AlbumName = settings.ImmichFrameAlbumName,
+                    AlbumName = Settings.CurrentSettings.ImmichFrameAlbumName,
                     Description = "Recent ImmichFrame Photos"
                 };
                 var result = await immichApi.CreateAlbumAsync(albumDto);
@@ -127,10 +125,9 @@ namespace ImmichFrame.Helpers
         {
             using (var client = new HttpClient())
             {
-                var settings = Settings.CurrentSettings;
-                client.UseApiKey(settings.ApiKey);
+                client.UseApiKey(Settings.CurrentSettings.ApiKey);
 
-                var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+                var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
 
                 var allAssets = new List<AssetResponseDto>();
 
@@ -176,12 +173,11 @@ namespace ImmichFrame.Helpers
             using var client = new HttpClient();
 
             var allAssets = new List<AssetResponseDto>();
-            var settings = Settings.CurrentSettings;
 
-            var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+            var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
 
-            client.UseApiKey(settings.ApiKey);
-            foreach (var albumId in settings.Albums!)
+            client.UseApiKey(Settings.CurrentSettings.ApiKey);
+            foreach (var albumId in Settings.CurrentSettings.Albums!)
             {
                 allAssets.AddRange(await GetAlbumAssets(albumId, immichApi));
             }
@@ -194,12 +190,11 @@ namespace ImmichFrame.Helpers
             using var client = new HttpClient();
 
             var allAssets = new List<AssetResponseDto>();
-            var settings = Settings.CurrentSettings;
 
-            var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+            var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
 
-            client.UseApiKey(settings.ApiKey);
-            foreach (var albumId in settings.ExcludedAlbums!)
+            client.UseApiKey(Settings.CurrentSettings.ApiKey);
+            foreach (var albumId in Settings.CurrentSettings.ExcludedAlbums!)
             {
                 allAssets.AddRange(await GetAlbumAssets(albumId, immichApi));
             }
@@ -212,12 +207,11 @@ namespace ImmichFrame.Helpers
             using (var client = new HttpClient())
             {
                 var allAssets = new List<AssetResponseDto>();
-                var settings = Settings.CurrentSettings;
 
-                var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+                var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
 
-                client.UseApiKey(settings.ApiKey);
-                foreach (var personId in settings.People!)
+                client.UseApiKey(Settings.CurrentSettings.ApiKey);
+                foreach (var personId in Settings.CurrentSettings.People!)
                 {
                     try
                     {
@@ -252,13 +246,11 @@ namespace ImmichFrame.Helpers
 
         private async Task<AssetResponseDto?> GetRandomAsset()
         {
-            var settings = Settings.CurrentSettings;
-
             using (var client = new HttpClient())
             {
-                client.UseApiKey(settings.ApiKey);
+                client.UseApiKey(Settings.CurrentSettings.ApiKey);
 
-                var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+                var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
                 try
                 {
                     var randomAssets = await immichApi.GetRandomAsync(null);

--- a/ImmichFrame/Helpers/LocationHelper.cs
+++ b/ImmichFrame/Helpers/LocationHelper.cs
@@ -28,8 +28,7 @@ namespace ImmichFrame.Helpers
 
         public static string GetLocationString(ImmichFrame.Models.ExifResponseDto exifInfo)
         {
-            var settings = Settings.CurrentSettings;
-            var locationParts = settings.ImageLocationFormat?.Split(',') ?? Array.Empty<string>();
+            var locationParts = Settings.CurrentSettings.ImageLocationFormat?.Split(',') ?? Array.Empty<string>();
 
             var city = locationParts.Length >= 1 ? exifInfo.City : string.Empty;
             var state = locationParts.Length >= 2 ? (exifInfo.State?.Split(", ").Last() ?? string.Empty) : string.Empty;

--- a/ImmichFrame/Helpers/WeatherHelper.cs
+++ b/ImmichFrame/Helpers/WeatherHelper.cs
@@ -10,14 +10,13 @@ namespace ImmichFrame.Helpers
     {
         public static Task<WeatherInfo?> GetWeather()
         {
-            var settings = Settings.CurrentSettings;
             OpenWeatherMapOptions options = new OpenWeatherMapOptions
             {
                 ApiKey = Settings.CurrentSettings.WeatherApiKey,
                 UnitSystem = Settings.CurrentSettings.UnitSystem,
                 Language = Settings.CurrentSettings.Language,
             };
-            return GetWeather(settings.WeatherLat, settings.WeatherLong, options);
+            return GetWeather(Settings.CurrentSettings.WeatherLat, Settings.CurrentSettings.WeatherLong, options);
         }
         public static async Task<WeatherInfo?> GetWeather(double latitude, double longitude, OpenWeatherMapOptions Options)
         {

--- a/ImmichFrame/Models/AssetResponseDto.cs
+++ b/ImmichFrame/Models/AssetResponseDto.cs
@@ -85,11 +85,9 @@ public partial class AssetResponseDto
     {
         using (var client = new HttpClient())
         {
-            var settings = Settings.CurrentSettings;
+            client.UseApiKey(Settings.CurrentSettings.ApiKey);
 
-            client.UseApiKey(settings.ApiKey);
-
-            var immichApi = new ImmichApi(settings.ImmichServerUrl, client);
+            var immichApi = new ImmichApi(Settings.CurrentSettings.ImmichServerUrl, client);
 
             var data = await immichApi.ViewAssetAsync(Guid.Parse(this.Id), string.Empty, AssetMediaSize.Preview);
 

--- a/ImmichFrame/Models/Settings.cs
+++ b/ImmichFrame/Models/Settings.cs
@@ -90,21 +90,21 @@ namespace ImmichFrame.Models
             }
         }
 
-        private static Settings? _settings;
+        private static Settings? currentSettings;
         public static Settings CurrentSettings
         {
             get
             {
-                if (_settings == null)
+                if (currentSettings == null)
                 {
                     if (!File.Exists(JsonSettingsPath))
                     {
                         CreateDefaultSettingsFile();
                     }
-                    _settings = ParseFromJson();
-                    _settings.Validate();
+                    currentSettings = ParseFromJson();
+                    currentSettings.Validate();
                 }
-                return _settings;
+                return currentSettings;
             }
         }
 
@@ -119,8 +119,8 @@ namespace ImmichFrame.Models
 
         public static void ReloadFromJson()
         {
-            _settings = ParseFromJson();
-            _settings.Validate();
+            currentSettings = ParseFromJson();
+            currentSettings.Validate();
         }
         private static Settings ParseFromJson()
         {
@@ -307,8 +307,8 @@ namespace ImmichFrame.Models
             using var streamReader = new StreamReader(stream, Encoding.UTF8);
             var jsonContents = await streamReader.ReadToEndAsync();
             var settings = JsonSerializer.Deserialize<Settings>(jsonContents, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            _settings = settings;
-            _settings!.Validate();
+            currentSettings = settings;
+            currentSettings!.Validate();
         }
         private static void CreateDefaultSettingsFile()
         {

--- a/ImmichFrame/ViewModels/SettingsViewModel.cs
+++ b/ImmichFrame/ViewModels/SettingsViewModel.cs
@@ -141,7 +141,7 @@ namespace ImmichFrame.ViewModels
                     return;
                 }
                 Settings.SaveSettings(Settings);
-                var settings = Settings.CurrentSettings;
+                Settings = Settings.CurrentSettings;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Don't create new instances of Settings everywhere, just directly use Setting.CurrentSettings (with the exception of ViewModels where the properties need to be observable).