### PR TITLE
Feat: Respect ImageFill configuration in splitview layout

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -80,7 +80,6 @@
 				<div class="grid grid-cols-2">
 					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-dvh-safe">
 						<Image
-							multi={true}
 							image={images[0]}
 							{interval}
 							{showLocation}
@@ -96,7 +95,6 @@
 					</div>
 					<div id="image_portrait_2" class="relative grid border-l-2 border-primary h-dvh-safe">
 						<Image
-							multi={true}
 							image={images[1]}
 							{interval}
 							{showLocation}

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -20,7 +20,6 @@
 		imageZoom: boolean;
 		imagePan: boolean;
 		interval: number;
-		multi?: boolean;
 		showInfo: boolean;
 	}
 
@@ -35,7 +34,6 @@
 		imageZoom,
 		imagePan,
 		interval,
-		multi = false,
 		showInfo = $bindable(false)
 	}: Props = $props();
 


### PR DESCRIPTION
Apply the ImageFill configuration option within splitview so that images are not cropped to fit.

Fixes #472

`ImageFill: true`:
<img width="752" height="358" alt="Screenshot 2025-09-23 at 10 57 06 AM" src="https://github.com/user-attachments/assets/03caeb97-1a38-45a3-9636-eeb13d05f438" />

`ImageFill: false` or unset:
<img width="754" height="357" alt="Screenshot 2025-09-23 at 10 58 45 AM" src="https://github.com/user-attachments/assets/72c9eba5-6dff-4e04-8581-7b488c43d05f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual consistency of images by unifying how fit/fill is applied across single and split-image layouts, reducing unexpected cropping or spacing differences.

* **Refactor**
  * Simplified image component configuration by removing an unused mode, reducing complexity and potential edge cases without changing core functionality for most users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->