### PR TITLE
Request memories using UTC

### DIFF
--- a/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
@@ -9,7 +9,7 @@ public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSetti
 {
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
-        var memories = await immichApi.SearchMemoriesAsync(DateTime.Now, null, null, null, ct);
+        var memories = await immichApi.SearchMemoriesAsync(DateTime.Today.ToUniversalTime(), null, null, null, ct);
 
         var memoryAssets = new List<AssetResponseDto>();
         foreach (var memory in memories)


### PR DESCRIPTION
Closes #478 
@JW-CH , do you think this is the issue for users seeing wrong days memories?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the date boundary used to retrieve memories to the start of the current day in UTC. This provides more consistent “Today” memories across time zones and reduces unexpected changes throughout the day. Users may notice steadier daily memory results and fewer discrepancies in which assets appear for a given day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->