### PR TITLE
Add release link to frameo docs

### DIFF
--- a/docs/docs/getting-started/apps.md
+++ b/docs/docs/getting-started/apps.md
@@ -13,7 +13,7 @@ See also: [ImmichFrame Apple TV repository][github-appletv-repo]
 You can "install" ImmichFrame as a PWA by opening in a browser and going to Share Menu-Add to Homescreen.
 
 ## Android
-The Android-Version of ImmichFrame is available on the [Google Play Store][play-store-link]. Download it via the store for automatic updates. You can also sideload via APK available in Releases.
+The Android-Version of ImmichFrame is available on the [Google Play Store][play-store-link]. Download it via the store for automatic updates. You can also sideload via APK available in [Releases][github-android-releases].
 
 See also: [ImmichFrame Android repository][github-android-repo]
 


### PR DESCRIPTION
This adds a link to the apk files in the ImmichFrame_Android releases

### Motivation
When I was setting up it up on my Frameo device, I didn't realize the releases were in a separate repo from ImmichFrame and spent more time looking for it than necessary. This should help people find it faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Android documentation links and cross-references for better navigation and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->