### PR TITLE
When Openweathermap calls for multiple images, split icon Id and get multiple images

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -75,8 +75,14 @@
 				id="clockweatherinfo"
 				class="text-xl sm:text-xl md:text-2xl lg:text-3xl font-semibold text-shadow-sm weather-info"
 			>
-				{#if $configStore.weatherIconUrl }
-				<img src="{ $configStore.weatherIconUrl.replace('{IconId}', encodeURIComponent(weather.iconId)) }" class="icon-weather" alt="{weather.description}">
+				{#if $configStore.weatherIconUrl}
+					{#each weather.iconId?.split(',') ?? [] as icon (icon)}
+						<img
+							src={$configStore.weatherIconUrl.replace('{IconId}', encodeURIComponent(icon.trim()))}
+							class="icon-weather"
+							alt={weather.description}
+						/>
+					{/each}
 				{/if}
 				<div class="weather-location">{weather.location},</div>
 				<div class="weather-temperature">{weather.temperature?.toFixed(1)}</div>


### PR DESCRIPTION
[Issue link](https://github.com/immichFrame/ImmichFrame/issues/523)

iconId is split at comma and then iterated over, producing icons per iconId.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The weather icon rendering on the clock widget has been enhanced to display multiple weather condition icons simultaneously. When multiple weather conditions are detected, each condition is now shown with its own corresponding icon, allowing users to gain a comprehensive understanding of current atmospheric conditions at a glance, rather than seeing only a single consolidated weather representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->