### PR TITLE
Fix: immichapi client generation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NSwag.ApiDescription.Client" Version="13.20.0" />
+    <PackageVersion Include="NSwag.ApiDescription.Client" Version="14.6.3" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -4,7 +4,7 @@
     {
         public ImmichApi(string url, System.Net.Http.HttpClient httpClient)
         {
-            _baseUrl = url + _baseUrl;
+            BaseUrl = url + "/api";
             _httpClient = httpClient;
             _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
         }


### PR DESCRIPTION
I recently switched to Linux as my OS. When generating the OpenAPI client, I had some issues. I am not sure why this worked before on Windows (WSL).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NSwag.ApiDescription.Client dependency from version 13.20.0 to 14.6.3.

* **Refactor**
  * Refactored internal API initialization configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->