### PR TITLE
Fix: Search calendar by DateTime.Today, not UtcNow

### DIFF
--- a/ImmichFrame.Core/Services/IcalCalendarService.cs
+++ b/ImmichFrame.Core/Services/IcalCalendarService.cs
@@ -51,7 +51,7 @@ public class IcalCalendarService : ICalendarService
             {
                 var calendar = Calendar.Load(ical);
 
-                appointments.AddRange(calendar.GetOccurrences(DateTime.UtcNow, DateTime.Today.AddDays(1)).Select(x => x.ToAppointment()));
+                appointments.AddRange(calendar.GetOccurrences(DateTime.Today, DateTime.Today.AddDays(1)).Select(x => x.ToAppointment()));
             }
 
             return appointments;


### PR DESCRIPTION
Closes #401 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar appointment retrieval to use local date rather than UTC time, ensuring correct appointments are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->