### PR TITLE
Feat: Remove weather unit, add degree symbol

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -90,8 +90,7 @@
             {/if}
             
             <div class="weather-location">{weather.location},</div>
-            <div class="weather-temperature">{weather.temperature?.toFixed(1)}</div>
-            <div class="weather-unit">{weather.unit}</div>
+            <div class="weather-temperature">{weather.temperature?.toFixed(1)}°</div>
         </div>
         
         {#if $configStore.showWeatherDescription}


### PR DESCRIPTION
The F/C weather unit seems unnecessary. Similar devices do not show this as it is assumed based on location.