### PR TITLE
Fix: Range header forwarding (Safari/iOS video fix)

### DIFF
--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -2,11 +2,44 @@
 {
     public partial class ImmichApi
     {
-        public ImmichApi(string url, System.Net.Http.HttpClient httpClient)
+        public ImmichApi(string url, HttpClient httpClient)
         {
             BaseUrl = url + "/api";
             _httpClient = httpClient;
-            _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
+            _settings = new Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
+        }
+
+        public async Task<FileResponse> PlayAssetVideoWithRangeAsync(Guid id, string rangeHeader, CancellationToken cancellationToken = default)
+        {
+            var urlBuilder = new System.Text.StringBuilder();
+            if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder.Append(_baseUrl);
+            urlBuilder.Append("assets/");
+            urlBuilder.Append(Uri.EscapeDataString(id.ToString("D", System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder.Append("/video/playback");
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, urlBuilder.ToString());
+            request.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
+            request.Headers.TryAddWithoutValidation("Range", rangeHeader);
+
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+            var headers = new Dictionary<string, IEnumerable<string>>();
+            foreach (var item in response.Headers)
+                headers[item.Key] = item.Value;
+            if (response.Content?.Headers != null)
+                foreach (var item in response.Content.Headers)
+                    headers[item.Key] = item.Value;
+
+            var status = (int)response.StatusCode;
+            if (status == 200 || status == 206)
+            {
+                var stream = response.Content == null ? Stream.Null : await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                return new FileResponse(status, headers, stream, null, response);
+            }
+
+            var error = response.Content == null ? null : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            response.Dispose();
+            throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
         }
     }
 }

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -13,7 +13,7 @@
         {
             var urlBuilder = new System.Text.StringBuilder();
             if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder.Append(_baseUrl);
-            urlBuilder.Append("/assets/");
+            urlBuilder.Append("assets/");
             urlBuilder.Append(Uri.EscapeDataString(id.ToString("D", System.Globalization.CultureInfo.InvariantCulture)));
             urlBuilder.Append("/video/playback");
 

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -13,7 +13,7 @@
         {
             var urlBuilder = new System.Text.StringBuilder();
             if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder.Append(_baseUrl);
-            urlBuilder.Append("assets/");
+            urlBuilder.Append("/assets/");
             urlBuilder.Append(Uri.EscapeDataString(id.ToString("D", System.Globalization.CultureInfo.InvariantCulture)));
             urlBuilder.Append("/video/playback");
 

--- a/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
@@ -9,7 +9,7 @@ namespace ImmichFrame.Core.Interfaces
         public Task<IEnumerable<AssetResponseDto>> GetAssets();
         public Task<AssetResponseDto> GetAssetInfoById(Guid assetId);
         public Task<IEnumerable<AlbumResponseDto>> GetAlbumInfoById(Guid assetId);
-        public Task<(string fileName, string ContentType, Stream fileStream)> GetAsset(Guid id, AssetTypeEnum? assetType = null);
+        public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null);
         public Task<long> GetTotalAssets();
         public Task SendWebhookNotification(IWebhookNotification notification);
     }

--- a/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
@@ -9,7 +9,7 @@ namespace ImmichFrame.Core.Interfaces
         public Task<IEnumerable<AssetResponseDto>> GetAssets();
         public Task<AssetResponseDto> GetAssetInfoById(Guid assetId);
         public Task<IEnumerable<AlbumResponseDto>> GetAlbumInfoById(Guid assetId);
-        public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null);
+        public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null);
         public Task<long> GetTotalAssets();
         public Task SendWebhookNotification(IWebhookNotification notification);
     }

--- a/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
@@ -1,4 +1,5 @@
 ﻿using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Models;
 
 
 namespace ImmichFrame.Core.Interfaces
@@ -9,7 +10,7 @@ namespace ImmichFrame.Core.Interfaces
         public Task<IEnumerable<AssetResponseDto>> GetAssets();
         public Task<AssetResponseDto> GetAssetInfoById(Guid assetId);
         public Task<IEnumerable<AlbumResponseDto>> GetAlbumInfoById(Guid assetId);
-        public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null);
+        public Task<AssetResponse> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null);
         public Task<long> GetTotalAssets();
         public Task SendWebhookNotification(IWebhookNotification notification);
     }

--- a/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
+++ b/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
@@ -42,8 +42,8 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
         => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAlbumInfoById(assetId));
 
 
-public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
-        => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
+    public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
+            => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
 
     public async Task<long> GetTotalAssets()
     {

--- a/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
+++ b/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
@@ -2,6 +2,7 @@ using System.Collections.Frozen;
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.Core.Models;
 using Microsoft.Extensions.Logging;
 
 namespace ImmichFrame.Core.Logic;
@@ -42,8 +43,8 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
         => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAlbumInfoById(assetId));
 
 
-    public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
-            => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
+    public Task<AssetResponse> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
+        => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
 
     public async Task<long> GetTotalAssets()
     {

--- a/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
+++ b/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
@@ -42,8 +42,8 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
         => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAlbumInfoById(assetId));
 
 
-    public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
-    => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
+public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
+        => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
 
     public async Task<long> GetTotalAssets()
     {

--- a/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
+++ b/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
@@ -42,8 +42,8 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
         => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAlbumInfoById(assetId));
 
 
-    public Task<(string fileName, string ContentType, Stream fileStream)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null)
-        => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType));
+    public Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetAsset(Guid assetId, AssetTypeEnum? assetType = null, string? rangeHeader = null)
+    => _accountSelectionStrategy.ForAsset(assetId, logic => logic.GetAsset(assetId, assetType, rangeHeader));
 
     public async Task<long> GetTotalAssets()
     {

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -4,7 +4,6 @@ using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.Core.Logic.Pool;
 using ImmichFrame.Core.Models;
-using System.Net.Http.Headers;
 
 namespace ImmichFrame.Core.Logic;
 
@@ -14,7 +13,6 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
     private readonly IApiCache _apiCache;
     private readonly IAssetPool _pool;
     private readonly ImmichApi _immichApi;
-    private readonly HttpClient _httpClient;
     private readonly string _downloadLocation = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ImageCache");
 
     public PooledImmichFrameLogic(IAccountSettings accountSettings, IGeneralSettings generalSettings, IHttpClientFactory httpClientFactory)
@@ -25,7 +23,6 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         AccountSettings = accountSettings;
 
         httpClient.UseApiKey(accountSettings.ApiKey);
-        _httpClient = httpClient;
         _immichApi = new ImmichApi(accountSettings.ImmichServerUrl, httpClient);
 
         _apiCache = new ApiCache(RefreshInterval(generalSettings.RefreshAlbumPeopleInterval));
@@ -173,41 +170,11 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         return (fileName, contentType, data.Stream);
     }
 
-    private async Task<FileResponse> PlayVideoWithRange(Guid id, string rangeHeader, CancellationToken cancellationToken = default)
-    {
-        var url = $"{_immichApi.BaseUrl.TrimEnd('/')}/assets/{id}/video/playback";
-
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
-        request.Headers.TryAddWithoutValidation("Range", rangeHeader);
-
-        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value);
-        if (response.Content?.Headers != null)
-            foreach (var item in response.Content.Headers)
-                headers[item.Key] = item.Value;
-
-        var status = (int)response.StatusCode;
-        if (status == 200 || status == 206)
-        {
-            var stream = response.Content == null ? Stream.Null : await response.Content.ReadAsStreamAsync(cancellationToken);
-            return new FileResponse(status, headers, stream, null, response);
-        }
-
-        var error = response.Content == null ? null : await response.Content.ReadAsStringAsync(cancellationToken);
-        response.Dispose();
-        throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
-    }
-
     private async Task<AssetResponse> GetVideoAsset(Guid id, string? rangeHeader = null)
     {
         var videoResponse = string.IsNullOrEmpty(rangeHeader)
             ? await _immichApi.PlayAssetVideoAsync(id, string.Empty)
-            : await PlayVideoWithRange(id, rangeHeader);
-
-        if (videoResponse == null)
-            throw new AssetNotFoundException($"Video asset {id} was not found!");
+            : await _immichApi.PlayAssetVideoWithRangeAsync(id, rangeHeader);
 
         var contentType = videoResponse.Headers.TryGetValue("Content-Type", out var ct)
             ? ct.FirstOrDefault() ?? "video/mp4"

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -83,7 +83,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
     public Task<long> GetTotalAssets() => _pool.GetAssetCount();
 
-    public async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null)
+    public async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null)
     {
         if (!assetType.HasValue)
         {
@@ -96,7 +96,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         if (assetType == AssetTypeEnum.IMAGE)
         {
             var (fileName, contentType, fileStream) = await GetImageAsset(id);
-            return (fileName, contentType, fileStream, null, false);
+            return (fileName, contentType, fileStream, null, false, null, null);
         }
 
         if (assetType == AssetTypeEnum.VIDEO)
@@ -106,7 +106,6 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
         throw new AssetNotFoundException($"Asset {id} is not a supported media type ({assetType}).");
     }
-
     private async Task<(string fileName, string ContentType, Stream fileStream)> GetImageAsset(Guid id)
     {
         if (_generalSettings.DownloadImages)
@@ -190,7 +189,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
     }
 
-    private async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetVideoAsset(Guid id, string? rangeHeader = null)
+    private async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetVideoAsset(Guid id, string? rangeHeader = null)
     {
         var videoResponse = string.IsNullOrEmpty(rangeHeader)
             ? await _immichApi.PlayAssetVideoAsync(id, string.Empty)
@@ -207,7 +206,9 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
             ? cr.FirstOrDefault()
             : null;
 
-        return ($"{id}.mp4", contentType, videoResponse.Stream, contentRange, videoResponse.StatusCode == 206);
+        var contentLength = videoResponse.Headers.TryGetValue("Content-Length", out var cl) ? cl.FirstOrDefault() : null;
+
+        return ($"{id}.mp4", contentType, videoResponse.Stream, contentRange, videoResponse.StatusCode == 206, videoResponse, contentLength);
     }
     public Task SendWebhookNotification(IWebhookNotification notification) =>
         WebhookHelper.SendWebhookNotification(notification, _generalSettings.Webhook);

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -101,7 +101,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
                 FileStream = fileStream,
                 ContentRange = null,
                 IsPartial = false,
-                Dispose = null,
+                Owner = null,
                 ContentLength = null
             };
         }
@@ -184,7 +184,8 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
             ? cr.FirstOrDefault()
             : null;
 
-        var contentLength = videoResponse.Headers.TryGetValue("Content-Length", out var cl) ? cl.FirstOrDefault() : null;
+        long? contentLength = videoResponse.Headers.TryGetValue("Content-Length", out var cl)
+            && long.TryParse(cl.FirstOrDefault(), out var clValue) ? clValue : null;
 
         return new AssetResponse
         {
@@ -193,7 +194,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
             FileStream = videoResponse.Stream,
             ContentRange = contentRange,
             IsPartial = videoResponse.StatusCode == 206,
-            Dispose = videoResponse,
+            Owner = videoResponse,
             ContentLength = contentLength
         };
     }

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -3,6 +3,7 @@ using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.Core.Logic.Pool;
+using ImmichFrame.Core.Models;
 using System.Net.Http.Headers;
 
 namespace ImmichFrame.Core.Logic;
@@ -83,7 +84,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
     public Task<long> GetTotalAssets() => _pool.GetAssetCount();
 
-    public async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null)
+    public async Task<AssetResponse> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null)
     {
         if (!assetType.HasValue)
         {
@@ -96,7 +97,16 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         if (assetType == AssetTypeEnum.IMAGE)
         {
             var (fileName, contentType, fileStream) = await GetImageAsset(id);
-            return (fileName, contentType, fileStream, null, false, null, null);
+            return new AssetResponse
+            {
+                FileName = fileName,
+                ContentType = contentType,
+                FileStream = fileStream,
+                ContentRange = null,
+                IsPartial = false,
+                Dispose = null,
+                ContentLength = null
+            };
         }
 
         if (assetType == AssetTypeEnum.VIDEO)
@@ -190,7 +200,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
     }
 
-    private async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial, IDisposable? dispose, string? contentLength)> GetVideoAsset(Guid id, string? rangeHeader = null)
+    private async Task<AssetResponse> GetVideoAsset(Guid id, string? rangeHeader = null)
     {
         var videoResponse = string.IsNullOrEmpty(rangeHeader)
             ? await _immichApi.PlayAssetVideoAsync(id, string.Empty)
@@ -209,7 +219,16 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
         var contentLength = videoResponse.Headers.TryGetValue("Content-Length", out var cl) ? cl.FirstOrDefault() : null;
 
-        return ($"{id}.mp4", contentType, videoResponse.Stream, contentRange, videoResponse.StatusCode == 206, videoResponse, contentLength);
+        return new AssetResponse
+        {
+            FileName = $"{id}.mp4",
+            ContentType = contentType,
+            FileStream = videoResponse.Stream,
+            ContentRange = contentRange,
+            IsPartial = videoResponse.StatusCode == 206,
+            Dispose = videoResponse,
+            ContentLength = contentLength
+        };
     }
     public Task SendWebhookNotification(IWebhookNotification notification) =>
         WebhookHelper.SendWebhookNotification(notification, _generalSettings.Webhook);

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -3,6 +3,7 @@ using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.Core.Logic.Pool;
+using System.Net.Http.Headers;
 
 namespace ImmichFrame.Core.Logic;
 
@@ -12,6 +13,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
     private readonly IApiCache _apiCache;
     private readonly IAssetPool _pool;
     private readonly ImmichApi _immichApi;
+    private readonly HttpClient _httpClient;
     private readonly string _downloadLocation = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ImageCache");
 
     public PooledImmichFrameLogic(IAccountSettings accountSettings, IGeneralSettings generalSettings, IHttpClientFactory httpClientFactory)
@@ -22,6 +24,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         AccountSettings = accountSettings;
 
         httpClient.UseApiKey(accountSettings.ApiKey);
+        _httpClient = httpClient;
         _immichApi = new ImmichApi(accountSettings.ImmichServerUrl, httpClient);
 
         _apiCache = new ApiCache(RefreshInterval(generalSettings.RefreshAlbumPeopleInterval));
@@ -80,7 +83,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
     public Task<long> GetTotalAssets() => _pool.GetAssetCount();
 
-    public async Task<(string fileName, string ContentType, Stream fileStream)> GetAsset(Guid id, AssetTypeEnum? assetType = null)
+    public async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetAsset(Guid id, AssetTypeEnum? assetType = null, string? rangeHeader = null)
     {
         if (!assetType.HasValue)
         {
@@ -92,12 +95,13 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
         if (assetType == AssetTypeEnum.IMAGE)
         {
-            return await GetImageAsset(id);
+            var (fileName, contentType, fileStream) = await GetImageAsset(id);
+            return (fileName, contentType, fileStream, null, false);
         }
 
         if (assetType == AssetTypeEnum.VIDEO)
         {
-            return await GetVideoAsset(id);
+            return await GetVideoAsset(id, rangeHeader);
         }
 
         throw new AssetNotFoundException($"Asset {id} is not a supported media type ({assetType}).");
@@ -160,79 +164,50 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         return (fileName, contentType, data.Stream);
     }
 
-    private async Task<(string fileName, string ContentType, Stream fileStream)> GetVideoAsset(Guid id)
+    private async Task<FileResponse> PlayVideoWithRange(Guid id, string rangeHeader, CancellationToken cancellationToken = default)
     {
-        var fileName = $"{id}.mp4";
-        string? filePath = null;
+        var url = $"{_immichApi.BaseUrl.TrimEnd('/')}/assets/{id}/video/playback";
 
-        if (_generalSettings.DownloadImages)
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
+        request.Headers.TryAddWithoutValidation("Range", rangeHeader);
+
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value);
+        if (response.Content?.Headers != null)
+            foreach (var item in response.Content.Headers)
+                headers[item.Key] = item.Value;
+
+        var status = (int)response.StatusCode;
+        if (status == 200 || status == 206)
         {
-            if (!Directory.Exists(_downloadLocation))
-            {
-                Directory.CreateDirectory(_downloadLocation);
-            }
-
-            filePath = Path.Combine(_downloadLocation, fileName);
-            if (File.Exists(filePath))
-            {
-                if (_generalSettings.RenewImagesDuration > (DateTime.UtcNow - File.GetCreationTimeUtc(filePath)).Days)
-                {
-                    return (fileName, "video/mp4", File.OpenRead(filePath));
-                }
-                File.Delete(filePath);
-            }
+            var stream = response.Content == null ? Stream.Null : await response.Content.ReadAsStreamAsync(cancellationToken);
+            return new FileResponse(status, headers, stream, null, response);
         }
 
-        using var videoResponse = await _immichApi.PlayAssetVideoAsync(id, string.Empty);
+        var error = response.Content == null ? null : await response.Content.ReadAsStringAsync(cancellationToken);
+        throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
+    }
+
+    private async Task<(string fileName, string ContentType, Stream fileStream, string? contentRange, bool isPartial)> GetVideoAsset(Guid id, string? rangeHeader = null)
+    {
+        var videoResponse = string.IsNullOrEmpty(rangeHeader)
+            ? await _immichApi.PlayAssetVideoAsync(id, string.Empty)
+            : await PlayVideoWithRange(id, rangeHeader);
+
         if (videoResponse == null)
             throw new AssetNotFoundException($"Video asset {id} was not found!");
 
-        var contentType = videoResponse.Headers.ContainsKey("Content-Type")
-            ? videoResponse.Headers["Content-Type"].FirstOrDefault() ?? "video/mp4"
+        var contentType = videoResponse.Headers.TryGetValue("Content-Type", out var ct)
+            ? ct.FirstOrDefault() ?? "video/mp4"
             : "video/mp4";
 
-        if (_generalSettings.DownloadImages)
-        {
-            var tempFilePath = filePath + ".tmp";
-            try
-            {
-                using (var fileStream = File.Create(tempFilePath))
-                {
-                    await videoResponse.Stream.CopyToAsync(fileStream);
-                }
+        var contentRange = videoResponse.Headers.TryGetValue("Content-Range", out var cr)
+            ? cr.FirstOrDefault()
+            : null;
 
-                File.Move(tempFilePath, filePath!, overwrite: true);
-                return (fileName, contentType, File.OpenRead(filePath!));
-            }
-            catch
-            {
-                if (File.Exists(tempFilePath))
-                    File.Delete(tempFilePath);
-                throw;
-            }
-        }
-
-        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.mp4");
-        var tempFileStream = new FileStream(
-            tempPath,
-            FileMode.Create,
-            FileAccess.ReadWrite,
-            FileShare.None,
-            4096,
-            FileOptions.DeleteOnClose | FileOptions.Asynchronous
-        );
-
-        try
-        {
-            await videoResponse.Stream.CopyToAsync(tempFileStream);
-            tempFileStream.Position = 0;
-            return (fileName, contentType, tempFileStream);
-        }
-        catch
-        {
-            tempFileStream.Dispose();
-            throw;
-        }
+        return ($"{id}.mp4", contentType, videoResponse.Stream, contentRange, videoResponse.StatusCode == 206);
     }
     public Task SendWebhookNotification(IWebhookNotification notification) =>
         WebhookHelper.SendWebhookNotification(notification, _generalSettings.Webhook);

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -186,6 +186,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         }
 
         var error = response.Content == null ? null : await response.Content.ReadAsStringAsync(cancellationToken);
+        response.Dispose();
         throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
     }
 

--- a/ImmichFrame.Core/Models/AssetResponse.cs
+++ b/ImmichFrame.Core/Models/AssetResponse.cs
@@ -7,6 +7,6 @@ public class AssetResponse
     public required Stream FileStream { get; init; }
     public string? ContentRange { get; init; }
     public bool IsPartial { get; init; }
-    public IDisposable? Dispose { get; init; }
-    public string? ContentLength { get; init; }
+    public IDisposable? Owner { get; init; }
+    public long? ContentLength { get; init; }
 }

--- a/ImmichFrame.Core/Models/AssetResponse.cs
+++ b/ImmichFrame.Core/Models/AssetResponse.cs
@@ -1,0 +1,12 @@
+namespace ImmichFrame.Core.Models;
+
+public class AssetResponse
+{
+    public required string FileName { get; init; }
+    public required string ContentType { get; init; }
+    public required Stream FileStream { get; init; }
+    public string? ContentRange { get; init; }
+    public bool IsPartial { get; init; }
+    public IDisposable? Dispose { get; init; }
+    public string? ContentLength { get; init; }
+}

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.Core.Models;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -72,13 +73,23 @@ namespace ImmichFrame.WebApi.Controllers
         [Produces("image/jpeg", "image/webp", "video/mp4", "video/quicktime")]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status206PartialContent)]
+        [ProducesResponseType(StatusCodes.Status416RangeNotSatisfiable)]
         public async Task<IActionResult> GetAsset(Guid id, string clientIdentifier = "", AssetTypeEnum? assetType = null)
         {
             var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
             _logger.LogDebug("Asset '{id}' requested by '{sanitizedClientIdentifier}' (type hint: {assetType})", id, sanitizedClientIdentifier, assetType);
 
             var rangeHeader = Request.Headers["Range"].FirstOrDefault();
-            var asset = await _logic.GetAsset(id, assetType, rangeHeader);
+
+            AssetResponse asset;
+            try
+            {
+                asset = await _logic.GetAsset(id, assetType, rangeHeader);
+            }
+            catch (ApiException ex) when (ex.StatusCode == 416)
+            {
+                return StatusCode(StatusCodes.Status416RangeNotSatisfiable);
+            }
 
             if (string.IsNullOrEmpty(rangeHeader))
             {
@@ -96,19 +107,18 @@ namespace ImmichFrame.WebApi.Controllers
 
                 if (asset.FileStream is { CanSeek: true } && asset.FileStream.Length > 0)
                     Response.ContentLength = asset.FileStream.Length;
-                else if (!string.IsNullOrEmpty(asset.ContentLength) && long.TryParse(asset.ContentLength, out var length))
-                    Response.ContentLength = length;
+                else if (asset.ContentLength.HasValue)
+                    Response.ContentLength = asset.ContentLength;
 
-                await using (asset.FileStream)
+                using (asset.Owner)
                 {
                     await asset.FileStream.CopyToAsync(Response.Body);
                 }
-                asset.Dispose?.Dispose();
                 return new EmptyResult();
             }
 
-            if (asset.Dispose != null)
-                HttpContext.Response.RegisterForDispose(asset.Dispose);
+            if (asset.Owner != null)
+                HttpContext.Response.RegisterForDispose(asset.Owner);
 
             return File(asset.FileStream, asset.ContentType, asset.FileName, enableRangeProcessing: true);
         }

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Interfaces;
-using ImmichFrame.Core.Models;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -108,10 +107,10 @@ namespace ImmichFrame.WebApi.Controllers
                 return new EmptyResult();
             }
 
-            using (asset.Dispose)
-            {
-                return File(asset.FileStream, asset.ContentType, asset.FileName, enableRangeProcessing: true);
-            }
+            if (asset.Dispose != null)
+                HttpContext.Response.RegisterForDispose(asset.Dispose);
+
+            return File(asset.FileStream, asset.ContentType, asset.FileName, enableRangeProcessing: true);
         }
 
         [HttpGet("RandomImageAndInfo", Name = "GetRandomImageAndInfo")]

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -90,11 +90,24 @@ namespace ImmichFrame.WebApi.Controllers
                 Response.Headers["Content-Range"] = asset.contentRange;
                 Response.StatusCode = 206;
                 Response.ContentType = asset.ContentType;
-                await asset.fileStream.CopyToAsync(Response.Body);
+
+                if (asset.fileStream is { CanSeek: true } && asset.fileStream.Length > 0)
+                    Response.ContentLength = asset.fileStream.Length;
+                else if (!string.IsNullOrEmpty(asset.contentLength) && long.TryParse(asset.contentLength, out var length))
+                    Response.ContentLength = length;
+
+                await using (asset.fileStream)
+                {
+                    await asset.fileStream.CopyToAsync(Response.Body);
+                }
+                asset.dispose?.Dispose();
                 return new EmptyResult();
             }
 
-            return File(asset.fileStream, asset.ContentType, asset.fileName, enableRangeProcessing: true);
+            using (asset.dispose)
+            {
+                return File(asset.fileStream, asset.ContentType, asset.fileName, enableRangeProcessing: true);
+            }
         }
 
         [HttpGet("RandomImageAndInfo", Name = "GetRandomImageAndInfo")]

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -63,7 +63,7 @@ namespace ImmichFrame.WebApi.Controllers
         [HttpGet("{id}/Image", Name = "GetImage")]
         [Produces("image/jpeg", "image/webp")]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
-        public async Task<FileResult> GetImage(Guid id, string clientIdentifier = "")
+        public async Task<IActionResult> GetImage(Guid id, string clientIdentifier = "")
         {
             return await GetAsset(id, clientIdentifier, AssetTypeEnum.IMAGE);
         }
@@ -71,14 +71,28 @@ namespace ImmichFrame.WebApi.Controllers
         [HttpGet("{id}/Asset", Name = "GetAsset")]
         [Produces("image/jpeg", "image/webp", "video/mp4", "video/quicktime")]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
-        public async Task<FileResult> GetAsset(Guid id, string clientIdentifier = "", AssetTypeEnum? assetType = null)
+        [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status206PartialContent)]
+        public async Task<IActionResult> GetAsset(Guid id, string clientIdentifier = "", AssetTypeEnum? assetType = null)
         {
             var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
             _logger.LogDebug("Asset '{id}' requested by '{sanitizedClientIdentifier}' (type hint: {assetType})", id, sanitizedClientIdentifier, assetType);
-            var asset = await _logic.GetAsset(id, assetType);
+
+            var rangeHeader = Request.Headers["Range"].FirstOrDefault();
+            var asset = await _logic.GetAsset(id, assetType, rangeHeader);
 
             var notification = new AssetRequestedNotification(id, sanitizedClientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
+
+            Response.Headers["Accept-Ranges"] = "bytes";
+
+            if (asset.isPartial && !string.IsNullOrEmpty(asset.contentRange))
+            {
+                Response.Headers["Content-Range"] = asset.contentRange;
+                Response.StatusCode = 206;
+                Response.ContentType = asset.ContentType;
+                await asset.fileStream.CopyToAsync(Response.Body);
+                return new EmptyResult();
+            }
 
             return File(asset.fileStream, asset.ContentType, asset.fileName, enableRangeProcessing: true);
         }

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -80,8 +80,11 @@ namespace ImmichFrame.WebApi.Controllers
             var rangeHeader = Request.Headers["Range"].FirstOrDefault();
             var asset = await _logic.GetAsset(id, assetType, rangeHeader);
 
-            var notification = new AssetRequestedNotification(id, sanitizedClientIdentifier);
-            _ = _logic.SendWebhookNotification(notification);
+            if (string.IsNullOrEmpty(rangeHeader))
+            {
+                var notification = new AssetRequestedNotification(id, sanitizedClientIdentifier);
+                _ = _logic.SendWebhookNotification(notification);
+            }
 
             Response.Headers["Accept-Ranges"] = "bytes";
 

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.Core.Models;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -88,28 +89,28 @@ namespace ImmichFrame.WebApi.Controllers
 
             Response.Headers["Accept-Ranges"] = "bytes";
 
-            if (asset.isPartial && !string.IsNullOrEmpty(asset.contentRange))
+            if (asset.IsPartial && !string.IsNullOrEmpty(asset.ContentRange))
             {
-                Response.Headers["Content-Range"] = asset.contentRange;
+                Response.Headers["Content-Range"] = asset.ContentRange;
                 Response.StatusCode = 206;
                 Response.ContentType = asset.ContentType;
 
-                if (asset.fileStream is { CanSeek: true } && asset.fileStream.Length > 0)
-                    Response.ContentLength = asset.fileStream.Length;
-                else if (!string.IsNullOrEmpty(asset.contentLength) && long.TryParse(asset.contentLength, out var length))
+                if (asset.FileStream is { CanSeek: true } && asset.FileStream.Length > 0)
+                    Response.ContentLength = asset.FileStream.Length;
+                else if (!string.IsNullOrEmpty(asset.ContentLength) && long.TryParse(asset.ContentLength, out var length))
                     Response.ContentLength = length;
 
-                await using (asset.fileStream)
+                await using (asset.FileStream)
                 {
-                    await asset.fileStream.CopyToAsync(Response.Body);
+                    await asset.FileStream.CopyToAsync(Response.Body);
                 }
-                asset.dispose?.Dispose();
+                asset.Dispose?.Dispose();
                 return new EmptyResult();
             }
 
-            using (asset.dispose)
+            using (asset.Dispose)
             {
-                return File(asset.fileStream, asset.ContentType, asset.fileName, enableRangeProcessing: true);
+                return File(asset.FileStream, asset.ContentType, asset.FileName, enableRangeProcessing: true);
             }
         }
 
@@ -143,7 +144,7 @@ namespace ImmichFrame.WebApi.Controllers
             string randomImageBase64;
             using (var memoryStream = new MemoryStream())
             {
-                await asset.fileStream.CopyToAsync(memoryStream);
+                await asset.FileStream.CopyToAsync(memoryStream);
                 randomImageBase64 = Convert.ToBase64String(memoryStream.ToArray());
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range-aware video playback endpoint with partial content (206), Accept-Ranges header and explicit 416 handling.
  * Client API: new range-aware playback method for streaming with range support.

* **Refactor**
  * Asset delivery now returns a structured AssetResponse including filename, content type, stream and metadata (content-range, content-length, partial flag, owner).

* **Bug Fixes**
  * Webhook notifications suppressed for range/partial requests to avoid redundant triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->