### PR TITLE
Feature/recent assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,3 +457,7 @@ $RECYCLE.BIN/
 ## Ignore Settings file
 ImmichFrame/Settings.json
 ImmichFrame.WebApi/Config/Settings.json
+.dotnet/
+Config/
+!Config/.gitkeep
+NuGet.Config

--- a/ImmichFrame.WebApi.Tests/Controllers/AssetRequestsControllerTests.cs
+++ b/ImmichFrame.WebApi.Tests/Controllers/AssetRequestsControllerTests.cs
@@ -1,0 +1,203 @@
+using System.Net.Http.Json;
+using ImmichFrame.WebApi.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using ImmichFrame.Core.Interfaces;
+using System.Net;
+
+namespace ImmichFrame.WebApi.Tests.Controllers;
+
+[TestFixture]
+public class AssetRequestsControllerTests
+{
+    private WebApplicationFactory<Program> _factory = null!;
+    private Mock<HttpMessageHandler> _mockHttpMessageHandler = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton<HttpMessageHandler>(_mockHttpMessageHandler.Object);
+                    services.AddHttpClient("ImmichApiAccountClient")
+                        .ConfigurePrimaryHttpMessageHandler(sp => sp.GetRequiredService<HttpMessageHandler>());
+                    services.ConfigureAll<HttpClientFactoryOptions>(options =>
+                    {
+                        options.HttpMessageHandlerBuilderActions.Add(b =>
+                        {
+                            b.PrimaryHandler = b.Services.GetRequiredService<HttpMessageHandler>();
+                        });
+                    });
+
+                    var generalSettings = new GeneralSettings
+                    {
+                        ShowWeatherDescription = false,
+                        WeatherIconUrl = "https://openweathermap.org/img/wn/{IconId}.png",
+                        ShowClock = true,
+                        ClockFormat = "HH:mm",
+                        ClockDateFormat = "eee, MMM d",
+                        Language = "en",
+                        PhotoDateFormat = "MM/dd/yyyy",
+                        ImageLocationFormat = "City,State,Country",
+                        DownloadImages = false,
+                        RenewImagesDuration = 30,
+                        PrimaryColor = "#FFFFFF",
+                        SecondaryColor = "#000000",
+                        Style = "none",
+                        BaseFontSize = "16px",
+                        WeatherApiKey = "",
+                        UnitSystem = "imperial",
+                        WeatherLatLong = "0,0"
+                    };
+
+                    var accountSettings = new ServerAccountSettings
+                    {
+                        ImmichServerUrl = "http://mock-immich-server.com",
+                        ApiKey = "test-api-key",
+                        ShowMemories = false,
+                        ShowFavorites = true,
+                        ShowArchived = false,
+                        Albums = [],
+                        ExcludedAlbums = [],
+                        People = []
+                    };
+
+                    var serverSettings = new ServerSettings
+                    {
+                        GeneralSettingsImpl = generalSettings,
+                        AccountsImpl = [accountSettings]
+                    };
+
+                    services.AddSingleton<IServerSettings>(serverSettings);
+                    services.AddSingleton<IGeneralSettings>(generalSettings);
+                });
+            });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _factory.Dispose();
+    }
+
+    [Test]
+    public async Task GetRecentAssetRequests_ReturnsLocationAndTakenTime()
+    {
+        var assetId = Guid.NewGuid();
+        SetupRecentAssetRequestMocks(assetId);
+
+        var client = _factory.CreateClient();
+        var imageResponse = await client.GetAsync("/api/Asset/RandomImageAndInfo?clientIdentifier=KitchenPanel");
+        imageResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/api/AssetRequests/RecentAssetRequests?limit=10");
+        response.EnsureSuccessStatusCode();
+
+        var recentRequests = await response.Content.ReadFromJsonAsync<List<RecentAssetRequestDetailsRecord>>();
+
+        Assert.That(recentRequests, Is.Not.Null);
+        var recentRequest = recentRequests!.Single(item => item.AssetId == assetId);
+        Assert.That(recentRequest.OriginalFileName, Is.EqualTo("kitchen-photo.jpg"));
+        Assert.That(recentRequest.Location, Is.EqualTo("Paris, Ile-de-France, France"));
+        Assert.That(recentRequest.TakenAtUtc, Is.Not.Null);
+    }
+
+    private void SetupRecentAssetRequestMocks(Guid assetId)
+    {
+        const string assetInfoTemplate = """
+        {
+            "id": "%ASSET_ID%",
+            "originalPath": "/path/to/image.jpg",
+            "type": "IMAGE",
+            "fileCreatedAt": "2023-10-26T10:00:00Z",
+            "fileModifiedAt": "2023-10-26T10:00:00Z",
+            "isFavorite": true,
+            "duration": "0:00:00",
+            "checksum": "testchecksum",
+            "deviceAssetId": "testDeviceAssetId",
+            "deviceId": "testDeviceId",
+            "ownerId": "testOwnerId",
+            "originalFileName": "kitchen-photo.jpg",
+            "localDateTime": "2023-10-26T10:00:00Z",
+            "visibility": "timeline",
+            "hasMetadata": true,
+            "isArchived": false,
+            "isOffline": false,
+            "isTrashed": false,
+            "thumbhash": "I0cMCQS94XmImZeXmYd3d3g=",
+            "updatedAt": "2023-10-26T10:00:00Z",
+            "exifInfo": {
+                "city": "Paris",
+                "state": "Ile-de-France",
+                "country": "France"
+            }
+        }
+        """;
+
+        var assetInfoJson = assetInfoTemplate.Replace("%ASSET_ID%", assetId.ToString());
+        var searchResponseJson = $$"""
+        {
+            "albums": {
+                "count": 0,
+                "items": [],
+                "total": 0,
+                "facets": []
+            },
+            "assets": {
+                "count": 1,
+                "items": [
+                    {{assetInfoJson}}
+                ],
+                "total": 1,
+                "facets": [],
+                "nextPage": null
+            }
+        }
+        """;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/search/metadata", StringComparison.OrdinalIgnoreCase)),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(searchResponseJson)
+            });
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri!.ToString().Contains($"/assets/{assetId}", StringComparison.OrdinalIgnoreCase) &&
+                    !req.RequestUri!.ToString().Contains("/thumbnail", StringComparison.OrdinalIgnoreCase)),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(assetInfoJson)
+            });
+
+        var mockImageData = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 };
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/thumbnail")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ByteArrayContent(mockImageData)
+            });
+    }
+}

--- a/ImmichFrame.WebApi.Tests/Controllers/AssetRequestsControllerTests.cs
+++ b/ImmichFrame.WebApi.Tests/Controllers/AssetRequestsControllerTests.cs
@@ -106,7 +106,7 @@ public class AssetRequestsControllerTests
 
         Assert.That(recentRequests, Is.Not.Null);
         var recentRequest = recentRequests!.Single(item => item.AssetId == assetId);
-        Assert.That(recentRequest.OriginalFileName, Is.EqualTo("kitchen-photo.jpg"));
+        Assert.That(recentRequest.CameraDisplay, Is.EqualTo("Canon EOS R6"));
         Assert.That(recentRequest.Location, Is.EqualTo("Paris, Ile-de-France, France"));
         Assert.That(recentRequest.TakenAtUtc, Is.Not.Null);
     }
@@ -136,6 +136,8 @@ public class AssetRequestsControllerTests
             "thumbhash": "I0cMCQS94XmImZeXmYd3d3g=",
             "updatedAt": "2023-10-26T10:00:00Z",
             "exifInfo": {
+                "make": "Canon",
+                "model": "EOS R6",
                 "city": "Paris",
                 "state": "Ile-de-France",
                 "country": "France"

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -4,6 +4,7 @@ using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.Core.Models;
 using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -26,12 +27,14 @@ namespace ImmichFrame.WebApi.Controllers
         private readonly ILogger<AssetController> _logger;
         private readonly IImmichFrameLogic _logic;
         private readonly IGeneralSettings _settings;
+        private readonly IAssetRequestTracker _tracker;
 
-        public AssetController(ILogger<AssetController> logger, IImmichFrameLogic logic, IGeneralSettings settings)
+        public AssetController(ILogger<AssetController> logger, IImmichFrameLogic logic, IGeneralSettings settings, IAssetRequestTracker tracker)
         {
             _logger = logger;
             _logic = logic;
             _settings = settings;
+            _tracker = tracker;
         }
 
         [HttpGet(Name = "GetAssets")]
@@ -93,6 +96,7 @@ namespace ImmichFrame.WebApi.Controllers
 
             if (string.IsNullOrEmpty(rangeHeader))
             {
+                _tracker.RecordAssetRequest(sanitizedClientIdentifier, id, "GET /api/Asset/{id}/Asset", assetType?.ToString());
                 var notification = new AssetRequestedNotification(id, sanitizedClientIdentifier);
                 _ = _logic.SendWebhookNotification(notification);
             }
@@ -146,8 +150,10 @@ namespace ImmichFrame.WebApi.Controllers
             if (randomAsset == null)
                 throw new AssetNotFoundException("No image asset was found");
 
-            var asset = await _logic.GetAsset(new Guid(randomAsset.Id), AssetTypeEnum.IMAGE);
-            var notification = new AssetRequestedNotification(new Guid(randomAsset.Id), sanitizedClientIdentifier);
+            var requestedAssetId = new Guid(randomAsset.Id);
+            var asset = await _logic.GetAsset(requestedAssetId, AssetTypeEnum.IMAGE);
+            _tracker.RecordAssetRequest(sanitizedClientIdentifier, requestedAssetId, "GET /api/Asset/RandomImageAndInfo", AssetTypeEnum.IMAGE.ToString());
+            var notification = new AssetRequestedNotification(requestedAssetId, sanitizedClientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
 
             string randomImageBase64;

--- a/ImmichFrame.WebApi/Controllers/AssetRequestsController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetRequestsController.cs
@@ -1,0 +1,81 @@
+using ImmichFrame.Core.Helpers;
+using ImmichFrame.Core.Interfaces;
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ImmichFrame.WebApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class AssetRequestsController(IAssetRequestTracker tracker, IImmichFrameLogic logic, ILogger<AssetRequestsController> logger) : ControllerBase
+{
+    [HttpGet("AssetRequests")]
+    [Produces("application/json")]
+    public ActionResult<IReadOnlyCollection<AssetRequestRecord>> GetAssetRequests(string? clientIdentifier = null, Guid? assetId = null, int limit = 100)
+    {
+        var sanitizedClientIdentifier = clientIdentifier?.SanitizeString() ?? string.Empty;
+        return Ok(tracker.GetAssetRequests(sanitizedClientIdentifier, assetId, limit));
+    }
+
+    [HttpGet("RecentAssetRequests")]
+    [Produces("application/json")]
+    public async Task<ActionResult<IReadOnlyCollection<RecentAssetRequestDetailsRecord>>> GetRecentAssetRequests(string? clientIdentifier = null, int limit = 10)
+    {
+        var sanitizedClientIdentifier = clientIdentifier?.SanitizeString() ?? string.Empty;
+        var requests = tracker.GetAssetRequests(sanitizedClientIdentifier, null, 1000);
+        var uniqueRecentRequests = requests
+            .GroupBy(request => request.AssetId)
+            .Select(group => group.First())
+            .Take(Math.Clamp(limit, 1, 1000));
+        var enrichedRequests = await Task.WhenAll(uniqueRecentRequests.Select(EnrichAssetRequestAsync));
+        return Ok(enrichedRequests);
+    }
+
+    private async Task<RecentAssetRequestDetailsRecord> EnrichAssetRequestAsync(AssetRequestRecord request)
+    {
+        try
+        {
+            var assetInfo = await logic.GetAssetInfoById(request.AssetId);
+            var city = assetInfo.ExifInfo?.City;
+            var state = assetInfo.ExifInfo?.State;
+            var country = assetInfo.ExifInfo?.Country;
+
+            return new RecentAssetRequestDetailsRecord
+            {
+                AssetId = request.AssetId,
+                ClientIdentifier = request.ClientIdentifier,
+                RequestedAtUtc = request.RequestedAtUtc,
+                Endpoint = request.Endpoint,
+                AssetType = request.AssetType,
+                OriginalFileName = assetInfo.OriginalFileName,
+                TakenAtUtc = assetInfo.LocalDateTime,
+                Location = string.Join(", ", new[] { city, state, country }.Where(part => !string.IsNullOrWhiteSpace(part))),
+                City = city,
+                State = state,
+                Country = country
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to enrich recent asset request for asset '{assetId}'", request.AssetId);
+
+            return new RecentAssetRequestDetailsRecord
+            {
+                AssetId = request.AssetId,
+                ClientIdentifier = request.ClientIdentifier,
+                RequestedAtUtc = request.RequestedAtUtc,
+                Endpoint = request.Endpoint,
+                AssetType = request.AssetType,
+                OriginalFileName = null,
+                TakenAtUtc = null,
+                Location = null,
+                City = null,
+                State = null,
+                Country = null
+            };
+        }
+    }
+}

--- a/ImmichFrame.WebApi/Controllers/AssetRequestsController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetRequestsController.cs
@@ -42,6 +42,8 @@ public class AssetRequestsController(IAssetRequestTracker tracker, IImmichFrameL
             var city = assetInfo.ExifInfo?.City;
             var state = assetInfo.ExifInfo?.State;
             var country = assetInfo.ExifInfo?.Country;
+            var cameraMake = assetInfo.ExifInfo?.Make;
+            var cameraModel = assetInfo.ExifInfo?.Model;
 
             return new RecentAssetRequestDetailsRecord
             {
@@ -51,6 +53,9 @@ public class AssetRequestsController(IAssetRequestTracker tracker, IImmichFrameL
                 Endpoint = request.Endpoint,
                 AssetType = request.AssetType,
                 OriginalFileName = assetInfo.OriginalFileName,
+                CameraMake = cameraMake,
+                CameraModel = cameraModel,
+                CameraDisplay = string.Join(" ", new[] { cameraMake, cameraModel }.Where(part => !string.IsNullOrWhiteSpace(part))),
                 TakenAtUtc = assetInfo.LocalDateTime,
                 Location = string.Join(", ", new[] { city, state, country }.Where(part => !string.IsNullOrWhiteSpace(part))),
                 City = city,
@@ -70,6 +75,9 @@ public class AssetRequestsController(IAssetRequestTracker tracker, IImmichFrameL
                 Endpoint = request.Endpoint,
                 AssetType = request.AssetType,
                 OriginalFileName = null,
+                CameraMake = null,
+                CameraModel = null,
+                CameraDisplay = null,
                 TakenAtUtc = null,
                 Location = null,
                 City = null,

--- a/ImmichFrame.WebApi/Models/ClientActivityModels.cs
+++ b/ImmichFrame.WebApi/Models/ClientActivityModels.cs
@@ -17,6 +17,9 @@ public sealed class RecentAssetRequestDetailsRecord
     public string? Endpoint { get; init; }
     public string? AssetType { get; init; }
     public string? OriginalFileName { get; init; }
+    public string? CameraMake { get; init; }
+    public string? CameraModel { get; init; }
+    public string? CameraDisplay { get; init; }
     public DateTimeOffset? TakenAtUtc { get; init; }
     public string? Location { get; init; }
     public string? City { get; init; }

--- a/ImmichFrame.WebApi/Models/ClientActivityModels.cs
+++ b/ImmichFrame.WebApi/Models/ClientActivityModels.cs
@@ -1,0 +1,25 @@
+namespace ImmichFrame.WebApi.Models;
+
+public sealed class AssetRequestRecord
+{
+    public required Guid AssetId { get; init; }
+    public required string ClientIdentifier { get; init; }
+    public required DateTimeOffset RequestedAtUtc { get; init; }
+    public string? Endpoint { get; init; }
+    public string? AssetType { get; init; }
+}
+
+public sealed class RecentAssetRequestDetailsRecord
+{
+    public required Guid AssetId { get; init; }
+    public required string ClientIdentifier { get; init; }
+    public required DateTimeOffset RequestedAtUtc { get; init; }
+    public string? Endpoint { get; init; }
+    public string? AssetType { get; init; }
+    public string? OriginalFileName { get; init; }
+    public DateTimeOffset? TakenAtUtc { get; init; }
+    public string? Location { get; init; }
+    public string? City { get; init; }
+    public string? State { get; init; }
+    public string? Country { get; init; }
+}

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using ImmichFrame.Core.Logic;
 using ImmichFrame.Core.Logic.AccountSelection;
 using ImmichFrame.WebApi.Helpers.Config;
+using ImmichFrame.WebApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 //log the version number
@@ -61,6 +62,7 @@ builder.Services.AddSingleton<IWeatherService, OpenWeatherMapService>();
 builder.Services.AddSingleton<ICalendarService, IcalCalendarService>();
 builder.Services.AddSingleton<IAssetAccountTracker, BloomFilterAssetAccountTracker>();
 builder.Services.AddSingleton<IAccountSelectionStrategy, TotalAccountImagesSelectionStrategy>();
+builder.Services.AddSingleton<IAssetRequestTracker, InMemoryAssetRequestTracker>();
 builder.Services.AddHttpClient(); // Ensures IHttpClientFactory is available
 
 builder.Services.AddTransient<Func<IAccountSettings, IAccountImmichFrameLogic>>(srv =>

--- a/ImmichFrame.WebApi/Services/IAssetRequestTracker.cs
+++ b/ImmichFrame.WebApi/Services/IAssetRequestTracker.cs
@@ -1,0 +1,9 @@
+using ImmichFrame.WebApi.Models;
+
+namespace ImmichFrame.WebApi.Services;
+
+public interface IAssetRequestTracker
+{
+    void RecordAssetRequest(string clientIdentifier, Guid assetId, string endpoint, string? assetType);
+    IReadOnlyCollection<AssetRequestRecord> GetAssetRequests(string? clientIdentifier, Guid? assetId, int limit);
+}

--- a/ImmichFrame.WebApi/Services/InMemoryAssetRequestTracker.cs
+++ b/ImmichFrame.WebApi/Services/InMemoryAssetRequestTracker.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using ImmichFrame.WebApi.Models;
+
+namespace ImmichFrame.WebApi.Services;
+
+internal sealed class InMemoryAssetRequestTracker : IAssetRequestTracker
+{
+    private const string AnonymousClientIdentifier = "anonymous";
+    private const int MaxAssetHistory = 1000;
+
+    private readonly ConcurrentQueue<AssetRequestRecord> _assetRequests = new();
+
+    public void RecordAssetRequest(string clientIdentifier, Guid assetId, string endpoint, string? assetType)
+    {
+        _assetRequests.Enqueue(new AssetRequestRecord
+        {
+            AssetId = assetId,
+            ClientIdentifier = NormalizeClientIdentifier(clientIdentifier),
+            RequestedAtUtc = DateTimeOffset.UtcNow,
+            Endpoint = endpoint,
+            AssetType = assetType
+        });
+
+        while (_assetRequests.Count > MaxAssetHistory && _assetRequests.TryDequeue(out _))
+        {
+        }
+    }
+
+    public IReadOnlyCollection<AssetRequestRecord> GetAssetRequests(string? clientIdentifier, Guid? assetId, int limit)
+    {
+        var normalizedClientIdentifier = string.IsNullOrWhiteSpace(clientIdentifier)
+            ? null
+            : NormalizeClientIdentifier(clientIdentifier);
+
+        return _assetRequests
+            .Reverse()
+            .Where(record => normalizedClientIdentifier == null || string.Equals(record.ClientIdentifier, normalizedClientIdentifier, StringComparison.OrdinalIgnoreCase))
+            .Where(record => assetId == null || record.AssetId == assetId.Value)
+            .Take(Math.Clamp(limit, 1, MaxAssetHistory))
+            .ToArray();
+    }
+
+    private static string NormalizeClientIdentifier(string clientIdentifier) =>
+        string.IsNullOrWhiteSpace(clientIdentifier) ? AnonymousClientIdentifier : clientIdentifier;
+}

--- a/docker/docker-compose.override.local.yml
+++ b/docker/docker-compose.override.local.yml
@@ -1,0 +1,13 @@
+name: immichframe-local
+
+services:
+  immichframe:
+    container_name: immichframe-local
+    image: immichframe:local
+    restart: unless-stopped
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./Config:/app/Config:ro
+    environment:
+      TZ: "Europe/London"

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -144,7 +144,7 @@
 <style>
 	.recent-requests-page {
 		min-height: 100vh;
-		padding: 2rem;
+		padding: calc(env(safe-area-inset-top, 0px) + 2.75rem) 2rem 2rem;
 		background:
 			radial-gradient(circle at top left, rgba(245, 222, 179, 0.28), transparent 35%),
 			linear-gradient(180deg, #18120a 0%, #090909 100%);
@@ -353,7 +353,7 @@
 
 	@media (max-width: 840px) {
 		.recent-requests-page {
-			padding: 1rem;
+			padding: calc(env(safe-area-inset-top, 0px) + 2rem) 1rem 1rem;
 		}
 
 		.request-grid {

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -9,6 +9,9 @@
 		endpoint?: string | null;
 		assetType?: string | null;
 		originalFileName?: string | null;
+		cameraMake?: string | null;
+		cameraModel?: string | null;
+		cameraDisplay?: string | null;
 		takenAtUtc?: string | null;
 		location?: string | null;
 		city?: string | null;
@@ -116,8 +119,10 @@
 		<div class="modal-content">
 			<div class="modal-header">
 				<div>
-					<p class="eyebrow modal-eyebrow">File Name
-					<h2 id="request-detail-title">{selectedRequest.originalFileName ?? selectedRequest.assetId}</h2>
+					<p class="eyebrow modal-eyebrow">Camera</p>
+					<h2 id="request-detail-title">
+						{selectedRequest.cameraDisplay || selectedRequest.cameraModel || selectedRequest.cameraMake || 'Unknown'}
+					</h2>
 				</div>
 				<button class="close-button" type="button" on:click={closeModal}>Close</button>
 			</div>

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -22,6 +22,7 @@
 	let errorMessage = '';
 	let recentRequests: RecentAssetRequest[] = [];
 	let selectedRequest: RecentAssetRequest | null = null;
+	let selectedImageIsPortrait = false;
 
 	const loadRecentRequests = async () => {
 		try {
@@ -44,6 +45,12 @@
 
 	const closeModal = () => {
 		selectedRequest = null;
+		selectedImageIsPortrait = false;
+	};
+
+	const handleModalImageLoad = (event: Event) => {
+		const image = event.currentTarget as HTMLImageElement;
+		selectedImageIsPortrait = image.naturalHeight > image.naturalWidth;
 	};
 
 	const formatDateTime = (value?: string | null) => {
@@ -99,9 +106,11 @@
 	<div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="request-detail-title">
 		<div class="modal-image-wrap">
 			<img
+				class:portrait-image={selectedImageIsPortrait}
 				class="modal-image"
 				src={getAssetStreamUrl(selectedRequest.assetId, selectedRequest.clientIdentifier, 0)}
 				alt={selectedRequest.originalFileName ?? selectedRequest.assetId}
+				on:load={handleModalImageLoad}
 			/>
 		</div>
 		<div class="modal-content">
@@ -277,6 +286,10 @@
 		object-fit: contain;
 	}
 
+	.portrait-image {
+		max-height: min(58vh, 32rem);
+	}
+
 	.modal-content {
 		padding: 1.4rem;
 	}
@@ -362,6 +375,10 @@
 
 		.modal-image-wrap {
 			padding: 0.75rem 0;
+		}
+
+		.portrait-image {
+			max-height: min(50vh, 24rem);
 		}
 
 		.page-header {

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -61,7 +61,7 @@
 		<div>
 			<p class="eyebrow">Asset Requests</p>
 			<h1>Recent Asset Requests</h1>
-			<p class="subtitle">The 10 most recently requested images, shown as clickable previews.</p>
+			<p class="subtitle">Recently requested images, shown as clickable previews.</p>
 		</div>
 	</header>
 

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -27,7 +27,7 @@
 		try {
 			isLoading = true;
 			errorMessage = '';
-			const response = await fetch('/api/AssetRequests/RecentAssetRequests?limit=10');
+			const response = await fetch('/api/AssetRequests/RecentAssetRequests?limit=12');
 			if (!response.ok) {
 				throw new Error(`Request failed with status ${response.status}`);
 			}

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -252,7 +252,7 @@
 		inset: 50% auto auto 50%;
 		transform: translate(-50%, -50%);
 		width: min(92vw, 56rem);
-		max-height: 88vh;
+		max-height: calc(100vh - 2rem);
 		overflow: auto;
 		display: grid;
 		grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
@@ -264,14 +264,20 @@
 
 	.modal-image-wrap {
 		background: #050505;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem 0;
+		overflow: hidden;
 	}
 
 	.modal-image {
 		display: block;
+		max-width: 100%;
 		width: 100%;
-		height: 100%;
-		min-height: 20rem;
-		object-fit: cover;
+		height: auto;
+		max-height: min(70vh, 40rem);
+		object-fit: contain;
 	}
 
 	.modal-content {
@@ -336,6 +342,8 @@
 
 		.modal-card {
 			grid-template-columns: 1fr;
+			width: min(92vw, 40rem);
+			max-height: calc(100vh - 2rem);
 		}
 	}
 

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -330,7 +330,7 @@
 		}
 
 		.request-grid {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
+			grid-template-columns: repeat(4, minmax(0, 1fr));
 			gap: 0.75rem;
 		}
 
@@ -349,7 +349,7 @@
 		}
 
 		.request-grid {
-			grid-template-columns: repeat(2, minmax(0, 1fr));
+			grid-template-columns: repeat(3, minmax(0, 1fr));
 		}
 	}
 </style>

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getAssetStreamUrl, init } from '$lib/index';
+
+	type RecentAssetRequest = {
+		assetId: string;
+		clientIdentifier: string;
+		requestedAtUtc: string;
+		endpoint?: string | null;
+		assetType?: string | null;
+		originalFileName?: string | null;
+		takenAtUtc?: string | null;
+		location?: string | null;
+		city?: string | null;
+		state?: string | null;
+		country?: string | null;
+	};
+
+	init();
+
+	let isLoading = true;
+	let errorMessage = '';
+	let recentRequests: RecentAssetRequest[] = [];
+	let selectedRequest: RecentAssetRequest | null = null;
+
+	onMount(async () => {
+		try {
+			const response = await fetch('/api/AssetRequests/RecentAssetRequests?limit=10');
+			if (!response.ok) {
+				throw new Error(`Request failed with status ${response.status}`);
+			}
+
+			recentRequests = await response.json();
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : 'Failed to load recent asset requests.';
+		} finally {
+			isLoading = false;
+		}
+	});
+
+	const closeModal = () => {
+		selectedRequest = null;
+	};
+
+	const formatDateTime = (value?: string | null) => {
+		if (!value) return 'Unknown';
+
+		return new Intl.DateTimeFormat(undefined, {
+			dateStyle: 'medium',
+			timeStyle: 'short'
+		}).format(new Date(value));
+	};
+</script>
+
+<svelte:head>
+	<title>Recent Asset Requests</title>
+</svelte:head>
+
+<div class="recent-requests-page">
+	<header class="page-header">
+		<div>
+			<p class="eyebrow">Asset Requests</p>
+			<h1>Recent Asset Requests</h1>
+			<p class="subtitle">The 10 most recently requested images, shown as clickable previews.</p>
+		</div>
+	</header>
+
+	{#if isLoading}
+		<p class="status-panel">Loading recent asset requests...</p>
+	{:else if errorMessage}
+		<p class="status-panel error">{errorMessage}</p>
+	{:else if recentRequests.length === 0}
+		<p class="status-panel">No asset requests have been recorded yet.</p>
+	{:else}
+		<div class="request-grid">
+			{#each recentRequests as request}
+				<button class="request-card" type="button" on:click={() => (selectedRequest = request)}>
+					<img
+						class="request-thumbnail"
+						src={getAssetStreamUrl(request.assetId, request.clientIdentifier, 0)}
+						alt={request.originalFileName ?? request.assetId}
+						loading="lazy"
+					/>
+					<div class="request-meta">
+						<p class="file-name">{request.originalFileName ?? request.assetId}</p>
+						<p>{formatDateTime(request.requestedAtUtc)}</p>
+					</div>
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+{#if selectedRequest}
+	<button class="modal-backdrop" type="button" aria-label="Close details" on:click={closeModal}></button>
+	<div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="request-detail-title">
+		<div class="modal-image-wrap">
+			<img
+				class="modal-image"
+				src={getAssetStreamUrl(selectedRequest.assetId, selectedRequest.clientIdentifier, 0)}
+				alt={selectedRequest.originalFileName ?? selectedRequest.assetId}
+			/>
+		</div>
+		<div class="modal-content">
+			<div class="modal-header">
+				<div>
+					<p class="eyebrow">Asset Detail</p>
+					<h2 id="request-detail-title">{selectedRequest.originalFileName ?? selectedRequest.assetId}</h2>
+				</div>
+				<button class="close-button" type="button" on:click={closeModal}>Close</button>
+			</div>
+
+			<dl class="detail-list">
+				<div>
+					<dt>Taken</dt>
+					<dd>{formatDateTime(selectedRequest.takenAtUtc)}</dd>
+				</div>
+				<div>
+					<dt>Location</dt>
+					<dd>{selectedRequest.location || 'Unknown'}</dd>
+				</div>
+				<div>
+					<dt>Requested</dt>
+					<dd>{formatDateTime(selectedRequest.requestedAtUtc)}</dd>
+				</div>
+				<div>
+					<dt>Client</dt>
+					<dd>{selectedRequest.clientIdentifier}</dd>
+				</div>
+			</dl>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.recent-requests-page {
+		min-height: 100vh;
+		padding: 2rem;
+		background:
+			radial-gradient(circle at top left, rgba(245, 222, 179, 0.28), transparent 35%),
+			linear-gradient(180deg, #18120a 0%, #090909 100%);
+		color: #f4efe4;
+	}
+
+	.page-header {
+		margin: 0 auto 2rem;
+		max-width: 72rem;
+	}
+
+	.eyebrow {
+		margin: 0 0 0.25rem;
+		font-size: 0.78rem;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: #d4b784;
+	}
+
+	h1 {
+		margin: 0;
+		font-size: clamp(2rem, 4vw, 3.5rem);
+		line-height: 0.95;
+	}
+
+	.subtitle {
+		margin-top: 0.75rem;
+		max-width: 40rem;
+		color: rgba(244, 239, 228, 0.72);
+	}
+
+	.status-panel {
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: 1rem 1.25rem;
+		border: 1px solid rgba(255, 255, 255, 0.12);
+		border-radius: 1rem;
+		background: rgba(255, 255, 255, 0.06);
+	}
+
+	.status-panel.error {
+		color: #ffb4b4;
+	}
+
+	.request-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: 1rem;
+		max-width: 72rem;
+		margin: 0 auto;
+	}
+
+	.request-card {
+		border: 0;
+		padding: 0;
+		text-align: left;
+		border-radius: 1.25rem;
+		overflow: hidden;
+		cursor: pointer;
+		background: rgba(255, 255, 255, 0.07);
+		box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+		transition:
+			transform 0.18s ease,
+			box-shadow 0.18s ease;
+	}
+
+	.request-card:hover {
+		transform: translateY(-3px);
+		box-shadow: 0 24px 48px rgba(0, 0, 0, 0.34);
+	}
+
+	.request-thumbnail {
+		display: block;
+		width: 100%;
+		aspect-ratio: 1 / 1;
+		object-fit: cover;
+		background: rgba(255, 255, 255, 0.04);
+	}
+
+	.request-meta {
+		padding: 0.9rem 1rem 1rem;
+	}
+
+	.file-name {
+		margin: 0 0 0.35rem;
+		font-weight: 700;
+		word-break: break-word;
+	}
+
+	.request-meta p:last-child {
+		margin: 0;
+		color: rgba(244, 239, 228, 0.72);
+		font-size: 0.88rem;
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.62);
+		border: 0;
+	}
+
+	.modal-card {
+		position: fixed;
+		inset: 50% auto auto 50%;
+		transform: translate(-50%, -50%);
+		width: min(92vw, 56rem);
+		max-height: 88vh;
+		overflow: auto;
+		display: grid;
+		grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+		background: #111111;
+		border: 1px solid rgba(255, 255, 255, 0.12);
+		border-radius: 1.4rem;
+		box-shadow: 0 36px 80px rgba(0, 0, 0, 0.42);
+	}
+
+	.modal-image-wrap {
+		background: #050505;
+	}
+
+	.modal-image {
+		display: block;
+		width: 100%;
+		height: 100%;
+		min-height: 20rem;
+		object-fit: cover;
+	}
+
+	.modal-content {
+		padding: 1.4rem;
+	}
+
+	.modal-header {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		align-items: start;
+	}
+
+	h2 {
+		margin: 0;
+		font-size: 1.35rem;
+		color: #f4efe4;
+	}
+
+	.close-button {
+		border: 1px solid rgba(255, 255, 255, 0.14);
+		background: transparent;
+		color: #d4b784;
+		padding: 0.6rem 0.9rem;
+		border-radius: 999px;
+		cursor: pointer;
+	}
+
+	.detail-list {
+		margin: 1.4rem 0 0;
+		display: grid;
+		gap: 1rem;
+	}
+
+	.detail-list div {
+		padding-top: 1rem;
+		border-top: 1px solid rgba(255, 255, 255, 0.08);
+	}
+
+	dt {
+		font-size: 0.78rem;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		color: #d4b784;
+	}
+
+	dd {
+		margin: 0.3rem 0 0;
+		font-size: 1rem;
+		color: rgba(244, 239, 228, 0.9);
+	}
+
+	@media (max-width: 840px) {
+		.recent-requests-page {
+			padding: 1rem;
+		}
+
+		.modal-card {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -107,7 +107,7 @@
 		<div class="modal-content">
 			<div class="modal-header">
 				<div>
-					<p class="eyebrow">Asset Detail</p>
+					<p class="eyebrow modal-eyebrow">File Name
 					<h2 id="request-detail-title">{selectedRequest.originalFileName ?? selectedRequest.assetId}</h2>
 				</div>
 				<button class="close-button" type="button" on:click={closeModal}>Close</button>
@@ -121,14 +121,6 @@
 				<div>
 					<dt>Location</dt>
 					<dd>{selectedRequest.location || 'Unknown'}</dd>
-				</div>
-				<div>
-					<dt>Requested</dt>
-					<dd>{formatDateTime(selectedRequest.requestedAtUtc)}</dd>
-				</div>
-				<div>
-					<dt>Client</dt>
-					<dd>{selectedRequest.clientIdentifier}</dd>
 				</div>
 			</dl>
 		</div>
@@ -160,6 +152,11 @@
 		letter-spacing: 0.16em;
 		text-transform: uppercase;
 		color: #d4b784;
+	}
+
+	.modal-eyebrow {
+		font-size: 0.68rem;
+		margin-bottom: 0.2rem;
 	}
 
 	h1 {
@@ -252,7 +249,7 @@
 		inset: 50% auto auto 50%;
 		transform: translate(-50%, -50%);
 		width: min(92vw, 56rem);
-		max-height: calc(100vh - 2rem);
+		max-height: calc(100vh - 3rem);
 		overflow: auto;
 		display: grid;
 		grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
@@ -293,8 +290,12 @@
 
 	h2 {
 		margin: 0;
-		font-size: 1.35rem;
+		font-size: 1.05rem;
+		line-height: 1.3;
+		font-weight: 400;
 		color: #f4efe4;
+		overflow-wrap: anywhere;
+		word-break: break-word;
 	}
 
 	.close-button {
@@ -328,6 +329,8 @@
 		margin: 0.3rem 0 0;
 		font-size: 1rem;
 		color: rgba(244, 239, 228, 0.9);
+		overflow-wrap: anywhere;
+		word-break: break-word;
 	}
 
 	@media (max-width: 840px) {
@@ -343,11 +346,24 @@
 		.modal-card {
 			grid-template-columns: 1fr;
 			width: min(92vw, 40rem);
-			max-height: calc(100vh - 2rem);
+			max-height: calc(100vh - 3rem);
 		}
 	}
 
 	@media (max-width: 480px) {
+		.modal-card {
+			width: calc(100vw - 1.5rem);
+			max-height: calc(100vh - 4rem);
+		}
+
+		.modal-content {
+			padding: 1rem;
+		}
+
+		.modal-image-wrap {
+			padding: 0.75rem 0;
+		}
+
 		.page-header {
 			gap: 0.75rem;
 		}

--- a/immichFrame.Web/src/routes/recent-requests/+page.svelte
+++ b/immichFrame.Web/src/routes/recent-requests/+page.svelte
@@ -23,8 +23,10 @@
 	let recentRequests: RecentAssetRequest[] = [];
 	let selectedRequest: RecentAssetRequest | null = null;
 
-	onMount(async () => {
+	const loadRecentRequests = async () => {
 		try {
+			isLoading = true;
+			errorMessage = '';
 			const response = await fetch('/api/AssetRequests/RecentAssetRequests?limit=10');
 			if (!response.ok) {
 				throw new Error(`Request failed with status ${response.status}`);
@@ -36,7 +38,9 @@
 		} finally {
 			isLoading = false;
 		}
-	});
+	};
+
+	onMount(loadRecentRequests);
 
 	const closeModal = () => {
 		selectedRequest = null;
@@ -61,8 +65,11 @@
 		<div>
 			<p class="eyebrow">Asset Requests</p>
 			<h1>Recent Asset Requests</h1>
-			<p class="subtitle">Recently requested images, shown as clickable previews.</p>
+			<p class="subtitle">Press previews to view info.</p>
 		</div>
+		<button class="refresh-button" type="button" on:click={loadRecentRequests} disabled={isLoading}>
+			{isLoading ? 'Refreshing...' : 'Refresh'}
+		</button>
 	</header>
 
 	{#if isLoading}
@@ -81,10 +88,6 @@
 						alt={request.originalFileName ?? request.assetId}
 						loading="lazy"
 					/>
-					<div class="request-meta">
-						<p class="file-name">{request.originalFileName ?? request.assetId}</p>
-						<p>{formatDateTime(request.requestedAtUtc)}</p>
-					</div>
 				</button>
 			{/each}
 		</div>
@@ -145,6 +148,10 @@
 	.page-header {
 		margin: 0 auto 2rem;
 		max-width: 72rem;
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
 	}
 
 	.eyebrow {
@@ -165,6 +172,24 @@
 		margin-top: 0.75rem;
 		max-width: 40rem;
 		color: rgba(244, 239, 228, 0.72);
+	}
+
+	.refresh-button {
+		border: 1px solid rgba(212, 183, 132, 0.45);
+		background: rgba(212, 183, 132, 0.08);
+		color: #d4b784;
+		padding: 0.7rem 1rem;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 700;
+		white-space: nowrap;
+		align-self: flex-start;
+		margin-left: auto;
+	}
+
+	.refresh-button:disabled {
+		opacity: 0.6;
+		cursor: default;
 	}
 
 	.status-panel {
@@ -213,22 +238,6 @@
 		aspect-ratio: 1 / 1;
 		object-fit: cover;
 		background: rgba(255, 255, 255, 0.04);
-	}
-
-	.request-meta {
-		padding: 0.9rem 1rem 1rem;
-	}
-
-	.file-name {
-		margin: 0 0 0.35rem;
-		font-weight: 700;
-		word-break: break-word;
-	}
-
-	.request-meta p:last-child {
-		margin: 0;
-		color: rgba(244, 239, 228, 0.72);
-		font-size: 0.88rem;
 	}
 
 	.modal-backdrop {
@@ -320,8 +329,27 @@
 			padding: 1rem;
 		}
 
+		.request-grid {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			gap: 0.75rem;
+		}
+
 		.modal-card {
 			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.page-header {
+			gap: 0.75rem;
+		}
+
+		.refresh-button {
+			padding: 0.6rem 0.85rem;
+		}
+
+		.request-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
 	}
 </style>

--- a/immichFrame.Web/static/manifest.webmanifest
+++ b/immichFrame.Web/static/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
     "name": "ImmichFrame",
     "short_name": "ImmichFrame",
-    "start_url": "/",
+    "start_url": "/recent-requests",
     "display": "fullscreen",
     "background_color": "#000000",
     "theme_color": "#000000",


### PR DESCRIPTION
For a while I’ve wanted an easy way to check the details of a photo that appears on my frame, especially older ones I haven’t seen in years, without walking across the room to read the small text or searching through my library for it. 

This change adds a new page you can visit on another device that shows the most recently displayed photos in a simple grid, and tapping a photo opens extra details such as when it was taken, where it was taken, and what camera was used.

---

<img width="302" height="656" alt="recent" src="https://github.com/user-attachments/assets/7546bf83-3cac-485c-ae29-4ec3ae9571db" />
<img width="302" height="656" alt="info" src="https://github.com/user-attachments/assets/c07f7ead-2ca3-4acd-8546-a685e7bdca0e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Recent Asset Requests" page featuring an interactive gallery of recently accessed assets with camera information, location, and capture date metadata
  * Modal viewer displays enlarged image previews and detailed asset information
  * Updated app's default landing page to display recent asset requests view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->