### PR TITLE
avoid duplicates in split view

### DIFF
--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -200,13 +200,7 @@
 	}
 
 	function removeDuplicateFromNextAssets(next: api.AssetResponseDto[]): api.AssetResponseDto[]{
-		// while(isDuplicate(next) && assetBacklog.length > 0){
-		// 	const duplicatePicture = next[0];
-		// 	next = assetBacklog.splice(0,1)
-		// 	next.push(duplicatePicture);
-		// }
 		if(isDuplicate(next)){
-			console.log("Duplicate detected!")
 			return next.slice(0,1);
 		}
 		return next;

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -180,7 +180,10 @@
 		}
 
 		const useSplit = shouldUseSplitView(assetBacklog);
-		const next = assetBacklog.splice(0, useSplit ? 2 : 1);
+		let next = assetBacklog.splice(0, useSplit ? 2 : 1);
+
+		next = removeDuplicateFromNextAssets(next);
+
 		assetBacklog = [...assetBacklog];
 
 		if (displayingAssets.length) {
@@ -194,6 +197,31 @@
 		displayingAssets = next;
 		await updateAssetPromises();
 		assetsState = await pickAssets(next);
+	}
+
+	function removeDuplicateFromNextAssets(next: api.AssetResponseDto[]): api.AssetResponseDto[]{
+		// while(isDuplicate(next) && assetBacklog.length > 0){
+		// 	const duplicatePicture = next[0];
+		// 	next = assetBacklog.splice(0,1)
+		// 	next.push(duplicatePicture);
+		// }
+		if(isDuplicate(next)){
+			console.log("Duplicate detected!")
+			return next.slice(0,1);
+		}
+		return next;
+	}
+
+	function isDuplicate(next: api.AssetResponseDto[]): boolean{
+		const seen = new Set<string>();
+
+		for(const item of next){
+			if(seen.has(item.id)){
+				return true;
+			}
+			seen.add(item.id);
+		}
+		return false;
 	}
 
 	async function getPreviousAssets() {

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -201,7 +201,12 @@
 
 	function removeDuplicateFromNextAssets(next: api.AssetResponseDto[]): api.AssetResponseDto[]{
 		if(isDuplicate(next)){
-			return next.slice(0,1);
+			const nextPortrait = tryPopNextNonDuplicatePortraitInBacklog([next[0]]);
+			let result = next.splice(0,1);
+			if(nextPortrait !== undefined) {
+				result.push(nextPortrait);
+			} 
+			return result;
 		}
 		return next;
 	}
@@ -216,6 +221,16 @@
 			seen.add(item.id);
 		}
 		return false;
+	}
+
+	function tryPopNextNonDuplicatePortraitInBacklog(next: api.AssetResponseDto[]): api.AssetResponseDto | undefined{
+		for(let i = 0; i < assetBacklog.length; i++){
+			const backlogAsset = assetBacklog[i];
+			if(!isPortrait(backlogAsset)) continue;
+			if(isDuplicate([...next, backlogAsset])) continue;
+			return assetBacklog.splice(i, 1)[0];
+		}
+		return undefined;
 	}
 
 	async function getPreviousAssets() {

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -202,7 +202,7 @@
 	function removeDuplicateFromNextAssets(next: api.AssetResponseDto[]): api.AssetResponseDto[]{
 		if(isDuplicate(next)){
 			const nextPortrait = tryPopNextNonDuplicatePortraitInBacklog([next[0]]);
-			let result = next.splice(0,1);
+			let result = [next[0]];
 			if(nextPortrait !== undefined) {
 				result.push(nextPortrait);
 			} 


### PR DESCRIPTION
# summary
On my immich frame instance I mainly want to show memories which there are not a whole lot of and I noticed that the side by side view sometimes shows duplicates. I don't think it should be that way, so i've implemented a small client-side function that will remove the duplicate picture based on it's id and show just a single photo.

# what did I change?
Since I don't know this codebase well and this is my first time contributing to an open-source project I thought i'd keep my change as small as possible so I just added a function to the home page. Let me know if this should be implemented in some other way!

# side effects
if you have only one image in the queue the ui looks the same regardless of the chosen layout in the config.

# issues
I saw someone mention this in: https://github.com/immichFrame/ImmichFrame/issues/464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate asset display when loading content in split-view and standard layouts so upcoming assets no longer repeat.
  * Improved browsing consistency by filtering the next-assets list and, when possible, substituting repeated items with a non-duplicate portrait from the backlog to keep displayed sets unique.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->