### PR TITLE
Added admin page with basic authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,3 +457,5 @@ $RECYCLE.BIN/
 ## Ignore Settings file
 ImmichFrame/Settings.json
 ImmichFrame.WebApi/Config/Settings.json
+ImmichFrame.WebApi/App_Data/admin-account.json
+ImmichFrame.WebApi/App_Data/frame-session-display-names.json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.2.0" />
+    <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="BloomFilter.NetCore" Version="2.5.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Ical.Net" Version="4.3.1" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,13 @@ WORKDIR /app
 # Optional: für Diagnostik bei Laufzeit
 ARG VERSION
 ENV APP_VERSION=$VERSION
+ENV ASPNETCORE_URLS=http://+:8080
 
 # Copy .NET API and frontend assets
 COPY --from=publish-api /app ./
 COPY --from=build-node /app/build ./wwwroot
+
+EXPOSE 8080
 
 # Set non-privileged user
 ARG APP_UID=1000

--- a/ImmichFrame.Core.Tests/ImmichFrame.Core.Tests.csproj
+++ b/ImmichFrame.Core.Tests/ImmichFrame.Core.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/ImmichFrame.Core/Api/AssetResponseDto.cs
+++ b/ImmichFrame.Core/Api/AssetResponseDto.cs
@@ -9,7 +9,7 @@ namespace ImmichFrame.Core.Api
         [JsonIgnore]
         public Stream? ThumbhashImage => GetThumbHashStream();
         
-        public string ImmichServerUrl { get; set; }
+        public string ImmichServerUrl { get; set; } = string.Empty;
 
         private Stream? GetThumbHashStream()
         {

--- a/ImmichFrame.Core/Helpers/ApiCache.cs
+++ b/ImmichFrame.Core/Helpers/ApiCache.cs
@@ -19,8 +19,12 @@ public class ApiCache : IApiCache, IDisposable
         _cacheOptions = entryOptions;
     }
 
-    public virtual Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
-        => _cache.GetOrCreateAsync<T>(key, _ => factory(), _cacheOptions());
+    public virtual async Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory) where T : notnull
+    {
+        var value = await _cache.GetOrCreateAsync<T>(key, _ => factory(), _cacheOptions());
+        ArgumentNullException.ThrowIfNull(value);
+        return value;
+    }
 
     public void Dispose()
         => _cache.Dispose();

--- a/ImmichFrame.Core/Interfaces/IApiCache.cs
+++ b/ImmichFrame.Core/Interfaces/IApiCache.cs
@@ -1,4 +1,4 @@
 public interface IApiCache
 {
-    Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory);
+    Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory) where T : notnull;
 }

--- a/ImmichFrame.Core/Logic/AccountSelection/TotalAccountImagesSelectionStrategy.cs
+++ b/ImmichFrame.Core/Logic/AccountSelection/TotalAccountImagesSelectionStrategy.cs
@@ -7,7 +7,7 @@ namespace ImmichFrame.Core.Logic.AccountSelection;
 
 public class TotalAccountImagesSelectionStrategy(ILogger<TotalAccountImagesSelectionStrategy> _logger, IAssetAccountTracker _tracker) : IAccountSelectionStrategy
 {
-    private IList<IAccountImmichFrameLogic> _accounts;
+    private IList<IAccountImmichFrameLogic> _accounts = [];
 
     public void Initialize(IList<IAccountImmichFrameLogic> accounts)
     {
@@ -16,7 +16,18 @@ public class TotalAccountImagesSelectionStrategy(ILogger<TotalAccountImagesSelec
 
     public async Task<(IAccountImmichFrameLogic, AssetResponseDto)?> GetNextAsset()
     {
+        if (_accounts.Count == 0)
+        {
+            _logger.LogDebug("No accounts are available for selection");
+            return null;
+        }
+
         var chosen = await _accounts.ChooseOne(logic => logic.GetTotalAssets());
+        if (chosen == null)
+        {
+            _logger.LogDebug("No account could be selected");
+            return null;
+        }
         
         var asset = await chosen.GetNextAsset();
         if (asset != null)
@@ -48,6 +59,12 @@ public class TotalAccountImagesSelectionStrategy(ILogger<TotalAccountImagesSelec
 
     public async Task<IEnumerable<(IAccountImmichFrameLogic, AssetResponseDto)>> GetAssets()
     {
+        if (_accounts.Count == 0)
+        {
+            _logger.LogDebug("No accounts are available for bulk asset selection");
+            return [];
+        }
+
         var proportions = await GetProportions(_accounts);
         var maxAccount = proportions.Max();
         var adjustedProportions = proportions.Select(x => x / maxAccount).ToList();

--- a/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
@@ -3,18 +3,23 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class AlbumAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class AlbumAssetsPool : CachingApiAssetsPool
 {
+    public AlbumAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        : base(apiCache, immichApi, accountSettings)
+    {
+    }
+
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var albumAssets = new List<AssetResponseDto>();
 
-        var albums = accountSettings.Albums;
+        var albums = AccountSettings.Albums;
         if (albums != null)
         {
             foreach (var albumId in albums)
             {
-                var albumInfo = await immichApi.GetAlbumInfoAsync(albumId, null, null, ct);
+                var albumInfo = await ImmichApi.GetAlbumInfoAsync(albumId, null, null, ct);
                 albumAssets.AddRange(albumInfo.Assets);
             }
         }

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -4,9 +4,20 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : IAssetPool
+public abstract class CachingApiAssetsPool : IAssetPool
 {
     private readonly Random _random = new();
+
+    protected CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+    {
+        ApiCache = apiCache;
+        ImmichApi = immichApi;
+        AccountSettings = accountSettings;
+    }
+
+    protected IApiCache ApiCache { get; }
+    protected ImmichApi ImmichApi { get; }
+    protected IAccountSettings AccountSettings { get; }
 
     public async Task<long> GetAssetCount(CancellationToken ct = default)
     {
@@ -20,9 +31,13 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
 
     private async Task<IEnumerable<AssetResponseDto>> AllAssets(CancellationToken ct = default)
     {
-        var excludedAlbumAssets = await apiCache.GetOrAddAsync($"{GetType().FullName}_ExcludedAlbums", () => AssetHelper.GetExcludedAlbumAssets(immichApi, accountSettings));
+        var excludedAlbumAssets = await ApiCache.GetOrAddAsync(
+            $"{GetType().FullName}_ExcludedAlbums",
+            () => AssetHelper.GetExcludedAlbumAssets(ImmichApi, AccountSettings));
 
-        return await apiCache.GetOrAddAsync(GetType().FullName!, () => LoadAssets().ApplyAccountFilters(accountSettings, excludedAlbumAssets));
+        return await ApiCache.GetOrAddAsync(
+            GetType().FullName!,
+            () => LoadAssets().ApplyAccountFilters(AccountSettings, excludedAlbumAssets));
     }
 
     protected abstract Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default);

--- a/ImmichFrame.Core/Logic/Pool/FavoriteAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/FavoriteAssetsPool.cs
@@ -3,8 +3,13 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class FavoriteAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class FavoriteAssetsPool : CachingApiAssetsPool
 {
+    public FavoriteAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        : base(apiCache, immichApi, accountSettings)
+    {
+    }
+
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var favoriteAssets = new List<AssetResponseDto>();
@@ -23,12 +28,12 @@ public class FavoriteAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccoun
                 WithPeople = true
             };
 
-            if (!accountSettings.ShowVideos)
+            if (!AccountSettings.ShowVideos)
             {
                 metadataBody.Type = AssetTypeEnum.IMAGE;
             }
 
-            var favoriteInfo = await immichApi.SearchAssetsAsync(metadataBody, ct);
+            var favoriteInfo = await ImmichApi.SearchAssetsAsync(metadataBody, ct);
 
             total = favoriteInfo.Assets.Total;
 

--- a/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
@@ -5,12 +5,17 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(new DailyApiCache(), immichApi, accountSettings)
+public class MemoryAssetsPool : CachingApiAssetsPool
 {
+    public MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSettings)
+        : base(new DailyApiCache(), immichApi, accountSettings)
+    {
+    }
+
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var searchDate = new DateTimeOffset(DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Utc), TimeSpan.Zero);
-        var memories = await immichApi.SearchMemoriesAsync(searchDate, null, null, null, ct);
+        var memories = await ImmichApi.SearchMemoriesAsync(searchDate, null, null, null, ct);
 
         var memoryAssets = new List<AssetResponseDto>();
         foreach (var memory in memories)
@@ -18,7 +23,7 @@ public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSetti
             var assets = memory.Assets.ToList();
             var yearsAgo = searchDate.Year - memory.Data.Year;
 
-            if (!accountSettings.ShowVideos)
+            if (!AccountSettings.ShowVideos)
             {
                 assets = assets.Where(a => a.Type == AssetTypeEnum.IMAGE).ToList();
             }
@@ -27,7 +32,7 @@ public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSetti
             {
                 if (asset.ExifInfo == null)
                 {
-                    var assetInfo = await immichApi.GetAssetInfoAsync(new Guid(asset.Id), null, ct);
+                    var assetInfo = await ImmichApi.GetAssetInfoAsync(new Guid(asset.Id), null, ct);
                     asset.ExifInfo = assetInfo.ExifInfo;
                     asset.People = assetInfo.People;
                 }

--- a/ImmichFrame.Core/Logic/Pool/PeopleAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/PeopleAssetsPool.cs
@@ -3,13 +3,18 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class PersonAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class PersonAssetsPool : CachingApiAssetsPool
 {
+    public PersonAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        : base(apiCache, immichApi, accountSettings)
+    {
+    }
+
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var personAssets = new List<AssetResponseDto>();
 
-        var people = accountSettings.People;
+        var people = AccountSettings.People;
         if (people == null)
         {
             return personAssets;
@@ -31,12 +36,12 @@ public class PersonAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountS
                     WithPeople = true
                 };
 
-                if (!accountSettings.ShowVideos)
+                if (!AccountSettings.ShowVideos)
                 {
                     metadataBody.Type = AssetTypeEnum.IMAGE;
                 }
 
-                var personInfo = await immichApi.SearchAssetsAsync(metadataBody, ct);
+                var personInfo = await ImmichApi.SearchAssetsAsync(metadataBody, ct);
 
                 total = personInfo.Assets.Total;
 

--- a/ImmichFrame.Core/Logic/Pool/TagAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/TagAssetsPool.cs
@@ -3,24 +3,30 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class TagAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class TagAssetsPool : CachingApiAssetsPool
 {
+    public TagAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        : base(apiCache, immichApi, accountSettings)
+    {
+    }
+
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var tagAssets = new List<AssetResponseDto>();
 
-        if (accountSettings.Tags == null)
+        if (AccountSettings.Tags == null)
         {
             return tagAssets;
         }
 
-        var allTags = await apiCache.GetOrAddAsync($"allTags_{accountSettings.ImmichServerUrl}",
-            () => immichApi.GetAllTagsAsync(ct));
+        var allTags = await ApiCache.GetOrAddAsync(
+            $"allTags_{AccountSettings.ImmichServerUrl}",
+            () => ImmichApi.GetAllTagsAsync(ct));
         var tagValueToTag = allTags.ToDictionary(t => t.Value);
 
         // Find the tags for the configured tag values
         var tags = new List<TagResponseDto>();
-        foreach (var tagValue in accountSettings.Tags)
+        foreach (var tagValue in AccountSettings.Tags)
         {
             if (tagValueToTag.TryGetValue(tagValue, out var tag))
             {
@@ -45,12 +51,12 @@ public class TagAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSett
                     WithPeople = true
                 };
 
-                if (!accountSettings.ShowVideos)
+                if (!AccountSettings.ShowVideos)
                 {
                     metadataBody.Type = AssetTypeEnum.IMAGE;
                 }
 
-                var tagInfo = await immichApi.SearchAssetsAsync(metadataBody, ct);
+                var tagInfo = await ImmichApi.SearchAssetsAsync(metadataBody, ct);
 
                 itemsInPage = tagInfo.Assets.Items.Count;
 

--- a/ImmichFrame.Core/Services/OpenWeatherMapService.cs
+++ b/ImmichFrame.Core/Services/OpenWeatherMapService.cs
@@ -3,6 +3,8 @@ using ImmichFrame.Core.Interfaces;
 
 public class OpenWeatherMapService : IWeatherService
 {
+    private sealed record CachedWeather(IWeather? Weather);
+
     private readonly IGeneralSettings _settings;
     private readonly IApiCache _weatherCache = new ApiCache(TimeSpan.FromMinutes(5));
     public OpenWeatherMapService(IGeneralSettings settings)
@@ -12,7 +14,7 @@ public class OpenWeatherMapService : IWeatherService
 
     public async Task<IWeather?> GetWeather()
     {
-        return await _weatherCache.GetOrAddAsync("weather", async () =>
+        var cachedWeather = await _weatherCache.GetOrAddAsync("weather", async () =>
         {
             var weatherLatLong = _settings.WeatherLatLong;
 
@@ -21,8 +23,10 @@ public class OpenWeatherMapService : IWeatherService
 
             var weather = await GetWeather(weatherLat, weatherLong);
 
-            return weather;
+            return new CachedWeather(weather);
         });
+
+        return cachedWeather.Weather;
     }
 
     public async Task<IWeather?> GetWeather(double latitude, double longitude)

--- a/ImmichFrame.WebApi.Tests/Controllers/FrameSessionsControllerTests.cs
+++ b/ImmichFrame.WebApi.Tests/Controllers/FrameSessionsControllerTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Net.Http.Json;
+using ImmichFrame.Core.Interfaces;
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace ImmichFrame.WebApi.Tests.Controllers;
+
+[TestFixture]
+public class FrameSessionsControllerTests
+{
+    private WebApplicationFactory<Program> _factory = null!;
+    private string? _originalBasicUser;
+    private string? _originalBasicHash;
+    private string? _originalAppDataPath;
+    private string _tempAppDataPath = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _originalBasicUser = Environment.GetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_USER");
+        _originalBasicHash = Environment.GetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_HASH");
+        _originalAppDataPath = Environment.GetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH");
+
+        _tempAppDataPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempAppDataPath);
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_USER", "admin");
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_HASH", "{SHA}" + Convert.ToBase64String(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes("secret"))));
+        Environment.SetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH", _tempAppDataPath);
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    var generalSettings = new GeneralSettings
+                    {
+                        AuthenticationSecret = "test-secret",
+                        PhotoDateFormat = "MM/dd/yyyy",
+                        ImageLocationFormat = "City,State,Country",
+                        Language = "en"
+                    };
+
+                    var accountSettings = new ServerAccountSettings
+                    {
+                        ImmichServerUrl = "http://mock-immich-server.com",
+                        ApiKey = "test-api-key"
+                    };
+
+                    var serverSettings = new ServerSettings
+                    {
+                        GeneralSettingsImpl = generalSettings,
+                        AccountsImpl = new List<ServerAccountSettings> { accountSettings }
+                    };
+
+                    services.AddSingleton<IServerSettings>(serverSettings);
+                    services.AddSingleton<IGeneralSettings>(generalSettings);
+                    services.AddSingleton<IFrameSessionRegistry, FrameSessionRegistry>();
+                });
+            });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _factory.Dispose();
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_USER", _originalBasicUser);
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_HASH", _originalBasicHash);
+        Environment.SetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH", _originalAppDataPath);
+
+        if (Directory.Exists(_tempAppDataPath))
+        {
+            Directory.Delete(_tempAppDataPath, true);
+        }
+    }
+
+    [Test]
+    public async Task AdminEndpoints_RequireAuthentication()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var response = await client.GetAsync("/api/admin/frame-sessions");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    [Test]
+    public async Task AdminAuthSession_ReturnsAuthenticatedUserAfterLogin()
+    {
+        var adminClient = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            HandleCookies = true
+        });
+
+        var sessionBeforeLogin = await adminClient.GetFromJsonAsync<AdminAuthSessionDto>("/api/admin/auth/session");
+        Assert.That(sessionBeforeLogin, Is.Not.Null);
+        Assert.That(sessionBeforeLogin!.IsConfigured, Is.True);
+        Assert.That(sessionBeforeLogin.IsAuthenticated, Is.False);
+
+        await LoginAdminAsync(adminClient);
+
+        var sessionAfterLogin = await adminClient.GetFromJsonAsync<AdminAuthSessionDto>("/api/admin/auth/session");
+        Assert.That(sessionAfterLogin, Is.Not.Null);
+        Assert.That(sessionAfterLogin!.IsAuthenticated, Is.True);
+        Assert.That(sessionAfterLogin.Username, Is.EqualTo("admin"));
+    }
+
+    [Test]
+    public async Task SessionLifecycle_ReturnsActiveSessionsAndCommands()
+    {
+        var frameClient = _factory.CreateClient();
+        frameClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "test-secret");
+
+        var snapshot = new FrameSessionSnapshotDto
+        {
+            PlaybackState = FramePlaybackState.Playing,
+            Status = FrameSessionStatus.Active,
+            CurrentDisplay = new DisplayEventDto
+            {
+                DisplayedAtUtc = DateTimeOffset.UtcNow,
+                DurationSeconds = 20,
+                Assets =
+                [
+                    new DisplayedAssetDto
+                    {
+                        Id = "asset-1",
+                        OriginalFileName = "current.jpg",
+                        Type = ImmichFrame.Core.Api.AssetTypeEnum.IMAGE,
+                        ImmichServerUrl = "http://mock-immich-server.com"
+                    }
+                ]
+            }
+        };
+
+        var putResponse = await frameClient.PutAsJsonAsync("/api/frame-sessions/frame-1", snapshot);
+        putResponse.EnsureSuccessStatusCode();
+
+        var adminClient = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            HandleCookies = true
+        });
+        await LoginAdminAsync(adminClient);
+
+        var adminResponse = await adminClient.GetFromJsonAsync<List<FrameSessionStateDto>>("/api/admin/frame-sessions");
+
+        Assert.That(adminResponse, Is.Not.Null);
+        Assert.That(adminResponse!, Has.Count.EqualTo(1));
+        Assert.That(adminResponse[0].ClientIdentifier, Is.EqualTo("frame1"));
+        Assert.That(adminResponse[0].CurrentDisplay?.Assets[0].OriginalFileName, Is.EqualTo("current.jpg"));
+        Assert.That(adminResponse[0].CurrentDisplay?.Assets[0].ImmichServerUrl, Is.EqualTo("http://mock-immich-server.com"));
+        Assert.That(adminResponse[0].CurrentDisplay?.DurationSeconds, Is.EqualTo(20));
+
+        var commandResponse = await adminClient.PostAsJsonAsync("/api/admin/frame-sessions/frame-1/commands", new EnqueueAdminCommandRequest
+        {
+            CommandType = FrameAdminCommandType.Next
+        });
+        commandResponse.EnsureSuccessStatusCode();
+
+        var commands = await frameClient.GetFromJsonAsync<List<AdminCommandDto>>("/api/frame-sessions/frame-1/commands");
+
+        Assert.That(commands, Is.Not.Null);
+        Assert.That(commands!, Has.Count.EqualTo(1));
+        Assert.That(commands[0].CommandType, Is.EqualTo(FrameAdminCommandType.Next));
+
+        var ackResponse = await frameClient.PostAsync($"/api/frame-sessions/frame-1/commands/{commands[0].CommandId}/ack", null);
+        ackResponse.EnsureSuccessStatusCode();
+
+        var commandsAfterAck = await frameClient.GetFromJsonAsync<List<AdminCommandDto>>("/api/frame-sessions/frame-1/commands");
+        Assert.That(commandsAfterAck, Is.Empty);
+    }
+
+    private static async Task LoginAdminAsync(HttpClient adminClient)
+    {
+        var loginResponse = await adminClient.PostAsJsonAsync("/api/admin/auth/login", new AdminLoginRequest
+        {
+            Username = "admin",
+            Password = "secret"
+        });
+
+        Assert.That(loginResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), await loginResponse.Content.ReadAsStringAsync());
+    }
+}

--- a/ImmichFrame.WebApi.Tests/Controllers/FrameSessionsControllerTests.cs
+++ b/ImmichFrame.WebApi.Tests/Controllers/FrameSessionsControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Collections;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.WebApi.Models;
 using ImmichFrame.WebApi.Services;
@@ -14,23 +15,13 @@ namespace ImmichFrame.WebApi.Tests.Controllers;
 public class FrameSessionsControllerTests
 {
     private WebApplicationFactory<Program> _factory = null!;
-    private string? _originalBasicUser;
-    private string? _originalBasicHash;
-    private string? _originalAppDataPath;
     private string _tempAppDataPath = null!;
 
     [SetUp]
     public void Setup()
     {
-        _originalBasicUser = Environment.GetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_USER");
-        _originalBasicHash = Environment.GetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_HASH");
-        _originalAppDataPath = Environment.GetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH");
-
         _tempAppDataPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempAppDataPath);
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_USER", "admin");
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_HASH", "{SHA}" + Convert.ToBase64String(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes("secret"))));
-        Environment.SetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH", _tempAppDataPath);
 
         _factory = new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
@@ -59,7 +50,21 @@ public class FrameSessionsControllerTests
 
                     services.AddSingleton<IServerSettings>(serverSettings);
                     services.AddSingleton<IGeneralSettings>(generalSettings);
-                    services.AddSingleton<IFrameSessionRegistry, FrameSessionRegistry>();
+                    services.AddSingleton<IAdminBasicAuthService>(_ =>
+                        new AdminBasicAuthService(new Hashtable
+                        {
+                            ["IMMICHFRAME_AUTH_BASIC_ADMIN_USER"] = "admin",
+                            ["IMMICHFRAME_AUTH_BASIC_ADMIN_HASH"] =
+                                "{SHA}" + Convert.ToBase64String(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes("secret")))
+                        }));
+                    services.AddSingleton<IFrameSessionRegistry>(_ =>
+                        new FrameSessionRegistry(
+                            new FrameSessionRegistryOptions
+                            {
+                                DisplayNameStorePath = Path.Combine(_tempAppDataPath, "frame-session-display-names.json")
+                            },
+                            null,
+                            null));
                 });
             });
     }
@@ -68,10 +73,6 @@ public class FrameSessionsControllerTests
     public void TearDown()
     {
         _factory.Dispose();
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_USER", _originalBasicUser);
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_ADMIN_HASH", _originalBasicHash);
-        Environment.SetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH", _originalAppDataPath);
-
         if (Directory.Exists(_tempAppDataPath))
         {
             Directory.Delete(_tempAppDataPath, true);
@@ -174,6 +175,29 @@ public class FrameSessionsControllerTests
 
         var commandsAfterAck = await frameClient.GetFromJsonAsync<List<AdminCommandDto>>("/api/frame-sessions/frame-1/commands");
         Assert.That(commandsAfterAck, Is.Empty);
+    }
+
+    [Test]
+    public async Task EnqueueCommand_ReturnsGoneForStaleSession()
+    {
+        var registry = _factory.Services.GetRequiredService<IFrameSessionRegistry>();
+        registry.UpsertSnapshot("framestale", new FrameSessionSnapshotDto(), "NUnit-Agent");
+        registry.MarkStopped("framestale", "NUnit-Agent");
+
+        var adminClient = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            HandleCookies = true
+        });
+        await LoginAdminAsync(adminClient);
+
+        var response = await adminClient.PostAsJsonAsync(
+            "/api/admin/frame-sessions/framestale/commands",
+            new EnqueueAdminCommandRequest
+            {
+                CommandType = FrameAdminCommandType.Refresh
+            });
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Gone));
     }
 
     private static async Task LoginAdminAsync(HttpClient adminClient)

--- a/ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj
+++ b/ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/ImmichFrame.WebApi.Tests/Services/AdminBasicAuthServiceTests.cs
+++ b/ImmichFrame.WebApi.Tests/Services/AdminBasicAuthServiceTests.cs
@@ -29,29 +29,23 @@ public class AdminBasicAuthServiceTests
     public void ValidateCredentials_SupportsApacheMd5AndSha1()
     {
         var aprHash = ApacheMd5Crypt.Hash("secret", "$apr1$xyw6b7Rb$");
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_USER", "sha-user");
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_HASH", "{SHA}" + Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes("sha-password"))));
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_USER", "apr-user");
-        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_HASH", aprHash);
-
-        try
+        IDictionary environment = new Hashtable
         {
-            var service = new AdminBasicAuthService();
+            ["IMMICHFRAME_AUTH_BASIC_SHA_USER"] = "sha-user",
+            ["IMMICHFRAME_AUTH_BASIC_SHA_HASH"] =
+                "{SHA}" + Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes("sha-password"))),
+            ["IMMICHFRAME_AUTH_BASIC_APR_USER"] = "apr-user",
+            ["IMMICHFRAME_AUTH_BASIC_APR_HASH"] = aprHash
+        };
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(service.HasUsers, Is.True);
-                Assert.That(service.ValidateCredentials("sha-user", "sha-password"), Is.True);
-                Assert.That(service.ValidateCredentials("apr-user", "secret"), Is.True);
-                Assert.That(service.ValidateCredentials("apr-user", "wrong"), Is.False);
-            });
-        }
-        finally
+        var service = new AdminBasicAuthService(environment);
+
+        Assert.Multiple(() =>
         {
-            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_USER", null);
-            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_HASH", null);
-            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_USER", null);
-            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_HASH", null);
-        }
+            Assert.That(service.HasUsers, Is.True);
+            Assert.That(service.ValidateCredentials("sha-user", "sha-password"), Is.True);
+            Assert.That(service.ValidateCredentials("apr-user", "secret"), Is.True);
+            Assert.That(service.ValidateCredentials("apr-user", "wrong"), Is.False);
+        });
     }
 }

--- a/ImmichFrame.WebApi.Tests/Services/AdminBasicAuthServiceTests.cs
+++ b/ImmichFrame.WebApi.Tests/Services/AdminBasicAuthServiceTests.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Security.Cryptography;
+using System.Text;
+using ImmichFrame.WebApi.Services;
+using NUnit.Framework;
+
+namespace ImmichFrame.WebApi.Tests.Services;
+
+[TestFixture]
+public class AdminBasicAuthServiceTests
+{
+    [Test]
+    public void LoadUsers_FindsCompleteUserHashPairs()
+    {
+        IDictionary environment = new Hashtable
+        {
+            ["IMMICHFRAME_AUTH_BASIC_JOHN_USER"] = "john",
+            ["IMMICHFRAME_AUTH_BASIC_JOHN_HASH"] = "{SHA}" + Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes("secret"))),
+            ["IMMICHFRAME_AUTH_BASIC_INCOMPLETE_USER"] = "ignored"
+        };
+
+        var users = AdminBasicAuthService.LoadUsers(environment);
+
+        Assert.That(users, Has.Count.EqualTo(1));
+        Assert.That(users[0].Username, Is.EqualTo("john"));
+    }
+
+    [Test]
+    public void ValidateCredentials_SupportsApacheMd5AndSha1()
+    {
+        var aprHash = ApacheMd5Crypt.Hash("secret", "$apr1$xyw6b7Rb$");
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_USER", "sha-user");
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_HASH", "{SHA}" + Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes("sha-password"))));
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_USER", "apr-user");
+        Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_HASH", aprHash);
+
+        try
+        {
+            var service = new AdminBasicAuthService();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(service.HasUsers, Is.True);
+                Assert.That(service.ValidateCredentials("sha-user", "sha-password"), Is.True);
+                Assert.That(service.ValidateCredentials("apr-user", "secret"), Is.True);
+                Assert.That(service.ValidateCredentials("apr-user", "wrong"), Is.False);
+            });
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_USER", null);
+            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_SHA_HASH", null);
+            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_USER", null);
+            Environment.SetEnvironmentVariable("IMMICHFRAME_AUTH_BASIC_APR_HASH", null);
+        }
+    }
+}

--- a/ImmichFrame.WebApi.Tests/Services/AdminBasicAuthServiceTests.cs
+++ b/ImmichFrame.WebApi.Tests/Services/AdminBasicAuthServiceTests.cs
@@ -48,4 +48,36 @@ public class AdminBasicAuthServiceTests
             Assert.That(service.ValidateCredentials("apr-user", "wrong"), Is.False);
         });
     }
+
+    [Test]
+    public void LoadUsers_ThrowsForDuplicateTrimmedUsernames()
+    {
+        IDictionary environment = new Hashtable
+        {
+            ["IMMICHFRAME_AUTH_BASIC_ONE_USER"] = " michel ",
+            ["IMMICHFRAME_AUTH_BASIC_ONE_HASH"] = "{SHA}" + Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes("secret-1"))),
+            ["IMMICHFRAME_AUTH_BASIC_TWO_USER"] = "michel",
+            ["IMMICHFRAME_AUTH_BASIC_TWO_HASH"] = "{SHA}" + Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes("secret-2")))
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => AdminBasicAuthService.LoadUsers(environment));
+
+        Assert.That(exception!.Message, Does.Contain("Duplicate admin username 'michel'"));
+        Assert.That(exception.Message, Does.Contain("IMMICHFRAME_AUTH_BASIC_ONE_USER"));
+        Assert.That(exception.Message, Does.Contain("IMMICHFRAME_AUTH_BASIC_TWO_USER"));
+    }
+
+    [Test]
+    public void ValidateCredentials_ReturnsFalseForMalformedBcryptHash()
+    {
+        IDictionary environment = new Hashtable
+        {
+            ["IMMICHFRAME_AUTH_BASIC_BAD_USER"] = "bad-user",
+            ["IMMICHFRAME_AUTH_BASIC_BAD_HASH"] = "$2bad-hash"
+        };
+
+        var service = new AdminBasicAuthService(environment);
+
+        Assert.That(service.ValidateCredentials("bad-user", "secret"), Is.False);
+    }
 }

--- a/ImmichFrame.WebApi.Tests/Services/FrameSessionRegistryTests.cs
+++ b/ImmichFrame.WebApi.Tests/Services/FrameSessionRegistryTests.cs
@@ -79,12 +79,13 @@ public class FrameSessionRegistryTests
 
         registry.UpsertSnapshot("frame-office", new FrameSessionSnapshotDto(), "NUnit-Agent");
 
-        var command = registry.EnqueueCommand("frame-office", FrameAdminCommandType.Next);
+        var result = registry.EnqueueCommand("frame-office", FrameAdminCommandType.Next);
         var pending = registry.GetPendingCommands("frame-office");
 
-        Assert.That(command, Is.Not.Null);
+        Assert.That(result.Status, Is.EqualTo(FrameSessionCommandEnqueueStatus.Enqueued));
+        Assert.That(result.Command, Is.Not.Null);
         Assert.That(pending, Has.Count.EqualTo(1));
-        Assert.That(registry.AcknowledgeCommand("frame-office", command!.CommandId), Is.True);
+        Assert.That(registry.AcknowledgeCommand("frame-office", result.Command!.CommandId), Is.True);
         Assert.That(registry.GetPendingCommands("frame-office"), Is.Empty);
     }
 
@@ -103,7 +104,9 @@ public class FrameSessionRegistryTests
         now = now.AddMinutes(6);
 
         Assert.That(registry.GetActiveSessions(), Is.Empty);
-        Assert.That(registry.EnqueueCommand("frame-den", FrameAdminCommandType.Refresh), Is.Null);
+        Assert.That(
+            registry.EnqueueCommand("frame-den", FrameAdminCommandType.Refresh).Status,
+            Is.EqualTo(FrameSessionCommandEnqueueStatus.NotFound));
     }
 
     [Test]
@@ -136,5 +139,38 @@ public class FrameSessionRegistryTests
                 File.Delete(tempFile);
             }
         }
+    }
+
+    [Test]
+    public void UpsertSnapshot_WithNullDisplayEventAssets_ClonesAsEmptyList()
+    {
+        var now = new DateTimeOffset(2026, 03, 25, 12, 00, 00, TimeSpan.Zero);
+        var registry = new FrameSessionRegistry(new FrameSessionRegistryOptions(), () => now);
+
+        registry.UpsertSnapshot("frame-porch", new FrameSessionSnapshotDto
+        {
+            CurrentDisplay = new DisplayEventDto
+            {
+                DisplayedAtUtc = now,
+                Assets = null!
+            },
+            History =
+            [
+                new DisplayEventDto
+                {
+                    DisplayedAtUtc = now.AddMinutes(-1),
+                    Assets = null!
+                }
+            ]
+        }, "NUnit-Agent");
+
+        var session = registry.GetActiveSessions().Single();
+
+        Assert.That(session.CurrentDisplay, Is.Not.Null);
+        Assert.That(session.CurrentDisplay!.Assets, Is.Not.Null);
+        Assert.That(session.CurrentDisplay.Assets, Is.Empty);
+        Assert.That(session.History, Has.Count.EqualTo(1));
+        Assert.That(session.History[0].Assets, Is.Not.Null);
+        Assert.That(session.History[0].Assets, Is.Empty);
     }
 }

--- a/ImmichFrame.WebApi.Tests/Services/FrameSessionRegistryTests.cs
+++ b/ImmichFrame.WebApi.Tests/Services/FrameSessionRegistryTests.cs
@@ -1,0 +1,140 @@
+using ImmichFrame.Core.Api;
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
+using NUnit.Framework;
+
+namespace ImmichFrame.WebApi.Tests.Services;
+
+[TestFixture]
+public class FrameSessionRegistryTests
+{
+    [Test]
+    public void UpsertSnapshot_TracksActiveSessionAndHistory()
+    {
+        var now = new DateTimeOffset(2026, 03, 25, 12, 00, 00, TimeSpan.Zero);
+        var registry = new FrameSessionRegistry(new FrameSessionRegistryOptions(), () => now);
+
+        registry.UpsertSnapshot("frame-kitchen", new FrameSessionSnapshotDto
+        {
+            PlaybackState = FramePlaybackState.Playing,
+            Status = FrameSessionStatus.Active,
+            CurrentDisplay = new DisplayEventDto
+            {
+                DisplayedAtUtc = now,
+                DurationSeconds = 45,
+                Assets =
+                [
+                    new DisplayedAssetDto
+                    {
+                        Id = "asset-1",
+                        OriginalFileName = "family.jpg",
+                        Type = AssetTypeEnum.IMAGE,
+                        ImmichServerUrl = "http://photos.example",
+                        LocalDateTime = now.ToString("O")
+                    }
+                ]
+            },
+            History =
+            [
+                new DisplayEventDto
+                {
+                    DisplayedAtUtc = now.AddMinutes(-2),
+                    DurationSeconds = 30,
+                    Assets =
+                    [
+                        new DisplayedAssetDto
+                        {
+                            Id = "asset-0",
+                            OriginalFileName = "vacation.jpg",
+                            Type = AssetTypeEnum.IMAGE,
+                            LocalDateTime = now.AddDays(-1).ToString("O")
+                        }
+                    ]
+                }
+            ]
+        }, "NUnit-Agent");
+
+        var sessions = registry.GetActiveSessions();
+
+        Assert.That(sessions, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(sessions[0].ClientIdentifier, Is.EqualTo("frame-kitchen"));
+            Assert.That(sessions[0].PlaybackState, Is.EqualTo(FramePlaybackState.Playing));
+            Assert.That(sessions[0].Status, Is.EqualTo(FrameSessionStatus.Active));
+            Assert.That(sessions[0].CurrentDisplay?.Assets[0].OriginalFileName, Is.EqualTo("family.jpg"));
+            Assert.That(sessions[0].CurrentDisplay?.Assets[0].ImmichServerUrl, Is.EqualTo("http://photos.example"));
+            Assert.That(sessions[0].CurrentDisplay?.DurationSeconds, Is.EqualTo(45));
+            Assert.That(sessions[0].History, Has.Count.EqualTo(1));
+            Assert.That(sessions[0].History[0].DurationSeconds, Is.EqualTo(30));
+            Assert.That(sessions[0].UserAgent, Is.EqualTo("NUnit-Agent"));
+        });
+    }
+
+    [Test]
+    public void CommandQueue_CanBeAcknowledged()
+    {
+        var now = new DateTimeOffset(2026, 03, 25, 12, 00, 00, TimeSpan.Zero);
+        var registry = new FrameSessionRegistry(new FrameSessionRegistryOptions(), () => now);
+
+        registry.UpsertSnapshot("frame-office", new FrameSessionSnapshotDto(), "NUnit-Agent");
+
+        var command = registry.EnqueueCommand("frame-office", FrameAdminCommandType.Next);
+        var pending = registry.GetPendingCommands("frame-office");
+
+        Assert.That(command, Is.Not.Null);
+        Assert.That(pending, Has.Count.EqualTo(1));
+        Assert.That(registry.AcknowledgeCommand("frame-office", command!.CommandId), Is.True);
+        Assert.That(registry.GetPendingCommands("frame-office"), Is.Empty);
+    }
+
+    [Test]
+    public void StaleSessions_ArePruned()
+    {
+        var now = new DateTimeOffset(2026, 03, 25, 12, 00, 00, TimeSpan.Zero);
+        var registry = new FrameSessionRegistry(new FrameSessionRegistryOptions
+        {
+            HeartbeatTtl = TimeSpan.FromSeconds(30),
+            StaleSessionTtl = TimeSpan.FromMinutes(5)
+        }, () => now);
+
+        registry.UpsertSnapshot("frame-den", new FrameSessionSnapshotDto(), "NUnit-Agent");
+
+        now = now.AddMinutes(6);
+
+        Assert.That(registry.GetActiveSessions(), Is.Empty);
+        Assert.That(registry.EnqueueCommand("frame-den", FrameAdminCommandType.Refresh), Is.Null);
+    }
+
+    [Test]
+    public void DisplayName_PersistsAcrossRegistryInstances()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}-frame-names.json");
+        try
+        {
+            var now = new DateTimeOffset(2026, 03, 25, 12, 00, 00, TimeSpan.Zero);
+            var options = new FrameSessionRegistryOptions
+            {
+                DisplayNameStorePath = tempFile
+            };
+
+            var writerRegistry = new FrameSessionRegistry(options, () => now);
+            writerRegistry.UpsertSnapshot("frame-kitchen", new FrameSessionSnapshotDto(), "NUnit-Agent");
+            Assert.That(writerRegistry.UpdateDisplayName("frame-kitchen", "Kitchen Frame"), Is.True);
+
+            var readerRegistry = new FrameSessionRegistry(options, () => now);
+            readerRegistry.UpsertSnapshot("frame-kitchen", new FrameSessionSnapshotDto(), "NUnit-Agent");
+
+            var sessions = readerRegistry.GetActiveSessions();
+            Assert.That(sessions, Has.Count.EqualTo(1));
+            Assert.That(sessions[0].DisplayName, Is.EqualTo("Kitchen Frame"));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+}

--- a/ImmichFrame.WebApi.Tests/Services/FrameSessionRegistryTests.cs
+++ b/ImmichFrame.WebApi.Tests/Services/FrameSessionRegistryTests.cs
@@ -173,4 +173,35 @@ public class FrameSessionRegistryTests
         Assert.That(session.History[0].Assets, Is.Not.Null);
         Assert.That(session.History[0].Assets, Is.Empty);
     }
+
+    [Test]
+    public void UpsertSnapshot_WithNullHistory_StoresEmptyHistory()
+    {
+        var now = new DateTimeOffset(2026, 03, 25, 12, 00, 00, TimeSpan.Zero);
+        var registry = new FrameSessionRegistry(new FrameSessionRegistryOptions(), () => now);
+
+        registry.UpsertSnapshot("frame-patio", new FrameSessionSnapshotDto
+        {
+            CurrentDisplay = new DisplayEventDto
+            {
+                DisplayedAtUtc = now,
+                Assets =
+                [
+                    new DisplayedAssetDto
+                    {
+                        Id = "asset-7",
+                        OriginalFileName = "garden.jpg",
+                        Type = AssetTypeEnum.IMAGE
+                    }
+                ]
+            },
+            History = null!
+        }, "NUnit-Agent");
+
+        var session = registry.GetActiveSessions().Single();
+
+        Assert.That(session.CurrentDisplay, Is.Not.Null);
+        Assert.That(session.History, Is.Not.Null);
+        Assert.That(session.History, Is.Empty);
+    }
 }

--- a/ImmichFrame.WebApi/App_Data/admin-account.json
+++ b/ImmichFrame.WebApi/App_Data/admin-account.json
@@ -1,5 +1,0 @@
-{
-  "Username": "test",
-  "PasswordHash": "AQAAAAIAAYagAAAAEGRlfmD2ialMu3eiTjbCzwIhzhHhx2nFb0IQzdvWQZzLmJlGidYiIT\u002BzPy7shbOeSg==",
-  "UpdatedAtUtc": "2026-03-28T20:35:16.16627+00:00"
-}

--- a/ImmichFrame.WebApi/App_Data/admin-account.json
+++ b/ImmichFrame.WebApi/App_Data/admin-account.json
@@ -1,0 +1,5 @@
+{
+  "Username": "test",
+  "PasswordHash": "AQAAAAIAAYagAAAAEGRlfmD2ialMu3eiTjbCzwIhzhHhx2nFb0IQzdvWQZzLmJlGidYiIT\u002BzPy7shbOeSg==",
+  "UpdatedAtUtc": "2026-03-28T20:35:16.16627+00:00"
+}

--- a/ImmichFrame.WebApi/App_Data/frame-session-display-names.json
+++ b/ImmichFrame.WebApi/App_Data/frame-session-display-names.json
@@ -1,0 +1,5 @@
+{
+  "1b8ebb4859c34bce8df8e713971758ff": "Michel\u0027s Office",
+  "1cda1299cb0b4015869b12903ce6840e": "Vivaldi",
+  "bcd063f97ef043b4aed41fd0dcacf85b": "Grandma\u0027s Frame"
+}

--- a/ImmichFrame.WebApi/App_Data/frame-session-display-names.json
+++ b/ImmichFrame.WebApi/App_Data/frame-session-display-names.json
@@ -1,5 +1,0 @@
-{
-  "1b8ebb4859c34bce8df8e713971758ff": "Michel\u0027s Office",
-  "1cda1299cb0b4015869b12903ce6840e": "Vivaldi",
-  "bcd063f97ef043b4aed41fd0dcacf85b": "Grandma\u0027s Frame"
-}

--- a/ImmichFrame.WebApi/Controllers/AdminAuthController.cs
+++ b/ImmichFrame.WebApi/Controllers/AdminAuthController.cs
@@ -4,6 +4,7 @@ using ImmichFrame.WebApi.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace ImmichFrame.WebApi.Controllers;
 
@@ -35,11 +36,17 @@ public class AdminAuthController : ControllerBase
 
     [HttpPost("login")]
     [AllowAnonymous]
+    [EnableRateLimiting("AdminLogin")]
     public async Task<ActionResult<AdminAuthSessionDto>> Login([FromBody] AdminLoginRequest request)
     {
         if (!_adminBasicAuthService.HasUsers)
         {
             return StatusCode(StatusCodes.Status503ServiceUnavailable, "Admin login is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Username) || string.IsNullOrWhiteSpace(request.Password))
+        {
+            return BadRequest("A username and password are required.");
         }
 
         if (!_adminBasicAuthService.ValidateCredentials(request.Username, request.Password))

--- a/ImmichFrame.WebApi/Controllers/AdminAuthController.cs
+++ b/ImmichFrame.WebApi/Controllers/AdminAuthController.cs
@@ -1,0 +1,82 @@
+using System.Security.Claims;
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ImmichFrame.WebApi.Controllers;
+
+[ApiController]
+[Route("api/admin/auth")]
+public class AdminAuthController : ControllerBase
+{
+    private readonly IAdminBasicAuthService _adminBasicAuthService;
+
+    public AdminAuthController(IAdminBasicAuthService adminBasicAuthService)
+    {
+        _adminBasicAuthService = adminBasicAuthService;
+    }
+
+    [HttpGet("session")]
+    [AllowAnonymous]
+    public async Task<ActionResult<AdminAuthSessionDto>> GetSession()
+    {
+        var authenticationResult = await HttpContext.AuthenticateAsync(AuthSchemes.Admin);
+        var principal = authenticationResult.Principal;
+
+        return Ok(new AdminAuthSessionDto
+        {
+            IsConfigured = _adminBasicAuthService.HasUsers,
+            IsAuthenticated = authenticationResult.Succeeded && principal?.Identity?.IsAuthenticated == true,
+            Username = principal?.FindFirstValue(ClaimTypes.Name)
+        });
+    }
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<ActionResult<AdminAuthSessionDto>> Login([FromBody] AdminLoginRequest request)
+    {
+        if (!_adminBasicAuthService.HasUsers)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Admin login is not configured.");
+        }
+
+        if (!_adminBasicAuthService.ValidateCredentials(request.Username, request.Password))
+        {
+            return Unauthorized("Invalid username or password.");
+        }
+
+        var credentialVersion = _adminBasicAuthService.GetCredentialVersion(request.Username);
+        if (string.IsNullOrWhiteSpace(credentialVersion))
+        {
+            return Unauthorized("Invalid username or password.");
+        }
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, request.Username),
+            new Claim(ClaimTypes.Name, request.Username),
+            new Claim("immichframe_admin_credential_version", credentialVersion)
+        };
+        var identity = new ClaimsIdentity(claims, AuthSchemes.Admin);
+        var principal = new ClaimsPrincipal(identity);
+
+        await HttpContext.SignInAsync(AuthSchemes.Admin, principal);
+
+        return Ok(new AdminAuthSessionDto
+        {
+            IsConfigured = true,
+            IsAuthenticated = true,
+            Username = request.Username
+        });
+    }
+
+    [HttpPost("logout")]
+    [Authorize(AuthenticationSchemes = AuthSchemes.Admin)]
+    public async Task<IActionResult> Logout()
+    {
+        await HttpContext.SignOutAsync(AuthSchemes.Admin);
+        return NoContent();
+    }
+}

--- a/ImmichFrame.WebApi/Controllers/AdminFrameSessionsController.cs
+++ b/ImmichFrame.WebApi/Controllers/AdminFrameSessionsController.cs
@@ -1,0 +1,60 @@
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ImmichFrame.WebApi.Controllers;
+
+[ApiController]
+[Route("api/admin/frame-sessions")]
+[Authorize(AuthenticationSchemes = AuthSchemes.Admin)]
+public class AdminFrameSessionsController : ControllerBase
+{
+    private readonly ILogger<AdminFrameSessionsController> _logger;
+    private readonly IFrameSessionRegistry _registry;
+
+    public AdminFrameSessionsController(ILogger<AdminFrameSessionsController> logger, IFrameSessionRegistry registry)
+    {
+        _logger = logger;
+        _registry = registry;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<FrameSessionStateDto>> GetActiveSessions()
+    {
+        return Ok(_registry.GetActiveSessions());
+    }
+
+    [HttpPost("{clientIdentifier}/commands")]
+    public ActionResult<AdminCommandDto> EnqueueCommand(string clientIdentifier, [FromBody] EnqueueAdminCommandRequest request)
+    {
+        var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
+        if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
+        {
+            return BadRequest("A valid client identifier is required.");
+        }
+
+        var command = _registry.EnqueueCommand(sanitizedClientIdentifier, request.CommandType);
+        if (command == null)
+        {
+            return NotFound();
+        }
+
+        _logger.LogInformation("Queued {commandType} command for frame session '{clientIdentifier}'", request.CommandType, sanitizedClientIdentifier);
+        return Ok(command);
+    }
+
+    [HttpPut("{clientIdentifier}/display-name")]
+    public IActionResult UpdateDisplayName(string clientIdentifier, [FromBody] UpdateFrameSessionDisplayNameRequest request)
+    {
+        var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
+        if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
+        {
+            return BadRequest("A valid client identifier is required.");
+        }
+
+        return _registry.UpdateDisplayName(sanitizedClientIdentifier, request.DisplayName)
+            ? NoContent()
+            : NotFound();
+    }
+}

--- a/ImmichFrame.WebApi/Controllers/AdminFrameSessionsController.cs
+++ b/ImmichFrame.WebApi/Controllers/AdminFrameSessionsController.cs
@@ -34,12 +34,21 @@ public class AdminFrameSessionsController : ControllerBase
             return BadRequest("A valid client identifier is required.");
         }
 
-        var command = _registry.EnqueueCommand(sanitizedClientIdentifier, request.CommandType);
-        if (command == null)
+        var result = _registry.EnqueueCommand(sanitizedClientIdentifier, request.CommandType);
+        if (result.Status == FrameSessionCommandEnqueueStatus.NotFound)
         {
             return NotFound();
         }
 
+        if (result.Status == FrameSessionCommandEnqueueStatus.Stale)
+        {
+            return Problem(
+                statusCode: StatusCodes.Status410Gone,
+                title: "Frame session is stale.",
+                detail: "The frame session is no longer active and cannot receive commands.");
+        }
+
+        var command = result.Command!;
         _logger.LogInformation("Queued {commandType} command for frame session '{clientIdentifier}'", request.CommandType, sanitizedClientIdentifier);
         return Ok(command);
     }

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -4,6 +4,7 @@ using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.Core.Models;
 using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,7 +21,7 @@ namespace ImmichFrame.WebApi.Controllers
 
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
+    [Authorize(AuthenticationSchemes = AuthSchemes.Frame)]
     public class AssetController : ControllerBase
     {
         private readonly ILogger<AssetController> _logger;

--- a/ImmichFrame.WebApi/Controllers/CalendarController.cs
+++ b/ImmichFrame.WebApi/Controllers/CalendarController.cs
@@ -1,12 +1,13 @@
 using ImmichFrame.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using ImmichFrame.WebApi.Services;
 
 namespace ImmichFrame.WebApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
+    [Authorize(AuthenticationSchemes = AuthSchemes.Frame)]
     public class CalendarController : ControllerBase
     {
         private readonly ILogger<AssetController> _logger;

--- a/ImmichFrame.WebApi/Controllers/FrameSessionsController.cs
+++ b/ImmichFrame.WebApi/Controllers/FrameSessionsController.cs
@@ -1,5 +1,6 @@
 using ImmichFrame.WebApi.Models;
 using ImmichFrame.WebApi.Services;
+using ImmichFrame.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,11 +13,16 @@ public class FrameSessionsController : ControllerBase
 {
     private readonly ILogger<FrameSessionsController> _logger;
     private readonly IFrameSessionRegistry _registry;
+    private readonly string? _authenticationSecret;
 
-    public FrameSessionsController(ILogger<FrameSessionsController> logger, IFrameSessionRegistry registry)
+    public FrameSessionsController(
+        ILogger<FrameSessionsController> logger,
+        IFrameSessionRegistry registry,
+        IGeneralSettings generalSettings)
     {
         _logger = logger;
         _registry = registry;
+        _authenticationSecret = generalSettings.AuthenticationSecret;
     }
 
     [HttpPut("{clientIdentifier}")]
@@ -60,8 +66,9 @@ public class FrameSessionsController : ControllerBase
             : NotFound();
     }
 
+    [AllowAnonymous]
     [HttpPost("{clientIdentifier}/disconnect")]
-    public IActionResult Disconnect(string clientIdentifier)
+    public IActionResult Disconnect(string clientIdentifier, [FromBody] FrameSessionDisconnectRequest? request)
     {
         var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
         if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
@@ -69,8 +76,30 @@ public class FrameSessionsController : ControllerBase
             return BadRequest("A valid client identifier is required.");
         }
 
+        if (!IsDisconnectAuthorized(request?.AuthSecret))
+        {
+            return Unauthorized();
+        }
+
         _logger.LogDebug("Frame session disconnect received for '{clientIdentifier}'", sanitizedClientIdentifier);
         _registry.MarkStopped(sanitizedClientIdentifier, Request.Headers.UserAgent.ToString());
         return NoContent();
+    }
+
+    private bool IsDisconnectAuthorized(string? requestAuthSecret)
+    {
+        if (string.IsNullOrWhiteSpace(_authenticationSecret))
+        {
+            return true;
+        }
+
+        var authorizationHeader = Request.Headers.Authorization.ToString();
+        if (authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            var token = authorizationHeader["Bearer ".Length..].Trim();
+            return string.Equals(token, _authenticationSecret, StringComparison.Ordinal);
+        }
+
+        return string.Equals(requestAuthSecret, _authenticationSecret, StringComparison.Ordinal);
     }
 }

--- a/ImmichFrame.WebApi/Controllers/FrameSessionsController.cs
+++ b/ImmichFrame.WebApi/Controllers/FrameSessionsController.cs
@@ -1,0 +1,76 @@
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.WebApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ImmichFrame.WebApi.Controllers;
+
+[ApiController]
+[Route("api/frame-sessions")]
+[Authorize(AuthenticationSchemes = AuthSchemes.Frame)]
+public class FrameSessionsController : ControllerBase
+{
+    private readonly ILogger<FrameSessionsController> _logger;
+    private readonly IFrameSessionRegistry _registry;
+
+    public FrameSessionsController(ILogger<FrameSessionsController> logger, IFrameSessionRegistry registry)
+    {
+        _logger = logger;
+        _registry = registry;
+    }
+
+    [HttpPut("{clientIdentifier}")]
+    public IActionResult UpsertSessionSnapshot(string clientIdentifier, [FromBody] FrameSessionSnapshotDto snapshot)
+    {
+        var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
+        if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
+        {
+            return BadRequest("A valid client identifier is required.");
+        }
+
+        _logger.LogDebug("Frame session snapshot received for '{clientIdentifier}'", sanitizedClientIdentifier);
+        _registry.UpsertSnapshot(sanitizedClientIdentifier, snapshot, Request.Headers.UserAgent.ToString());
+        return NoContent();
+    }
+
+    [HttpGet("{clientIdentifier}/commands")]
+    public ActionResult<IReadOnlyList<AdminCommandDto>> GetPendingCommands(string clientIdentifier)
+    {
+        var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
+        if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
+        {
+            return BadRequest("A valid client identifier is required.");
+        }
+
+        var commands = _registry.GetPendingCommands(sanitizedClientIdentifier);
+        return Ok(commands);
+    }
+
+    [HttpPost("{clientIdentifier}/commands/{commandId:long}/ack")]
+    public IActionResult AcknowledgeCommand(string clientIdentifier, long commandId)
+    {
+        var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
+        if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
+        {
+            return BadRequest("A valid client identifier is required.");
+        }
+
+        return _registry.AcknowledgeCommand(sanitizedClientIdentifier, commandId)
+            ? NoContent()
+            : NotFound();
+    }
+
+    [HttpPost("{clientIdentifier}/disconnect")]
+    public IActionResult Disconnect(string clientIdentifier)
+    {
+        var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
+        if (string.IsNullOrWhiteSpace(sanitizedClientIdentifier))
+        {
+            return BadRequest("A valid client identifier is required.");
+        }
+
+        _logger.LogDebug("Frame session disconnect received for '{clientIdentifier}'", sanitizedClientIdentifier);
+        _registry.MarkStopped(sanitizedClientIdentifier, Request.Headers.UserAgent.ToString());
+        return NoContent();
+    }
+}

--- a/ImmichFrame.WebApi/Controllers/WeatherController.cs
+++ b/ImmichFrame.WebApi/Controllers/WeatherController.cs
@@ -1,12 +1,13 @@
 using ImmichFrame.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using ImmichFrame.WebApi.Services;
 
 namespace ImmichFrame.WebApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
+    [Authorize(AuthenticationSchemes = AuthSchemes.Frame)]
     public class WeatherController : ControllerBase
     {
         private readonly ILogger<AssetController> _logger;

--- a/ImmichFrame.WebApi/Helpers/ImmichFrameAuthenticationHandler.cs
+++ b/ImmichFrame.WebApi/Helpers/ImmichFrameAuthenticationHandler.cs
@@ -45,7 +45,7 @@ public class ImmichFrameAuthenticationHandler : AuthenticationHandler<Authentica
     {
         var endpoint = Context.GetEndpoint();
         var authorizeAttribute = endpoint?.Metadata?.GetMetadata<IAuthorizeData>();
-        return _authenticationSecret != null && authorizeAttribute != null;
+        return !string.IsNullOrWhiteSpace(_authenticationSecret) && authorizeAttribute != null;
     }
 
     private static bool TryGetBearerToken(string? authorizationHeader, out string token)

--- a/ImmichFrame.WebApi/Helpers/ImmichFrameAuthenticationHandler.cs
+++ b/ImmichFrame.WebApi/Helpers/ImmichFrameAuthenticationHandler.cs
@@ -22,43 +22,52 @@ public class ImmichFrameAuthenticationHandler : AuthenticationHandler<Authentica
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        var endpoint = Context.GetEndpoint();
-        var authorizeAttribute = endpoint?.Metadata?.GetMetadata<IAuthorizeData>();
-
-        if (_authenticationSecret == null || authorizeAttribute == null)
+        if (!RequiresAuthentication())
         {
-            // No auth is required
-            var claims = new[] { new Claim(ClaimTypes.NameIdentifier, "anonymous") };
-            var identity = new ClaimsIdentity(claims, Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-
-            return Task.FromResult(AuthenticateResult.Success(ticket));
+            return Task.FromResult(CreateSuccessResult("anonymous"));
         }
 
-        if (!Request.Headers.ContainsKey("Authorization"))
+        if (TryGetBearerToken(Request.Headers.Authorization.ToString(), out var token) &&
+            string.Equals(token, _authenticationSecret, StringComparison.Ordinal))
+        {
+            return Task.FromResult(CreateSuccessResult("authenticatedUser"));
+        }
+
+        if (string.IsNullOrWhiteSpace(Request.Headers.Authorization))
         {
             return Task.FromResult(AuthenticateResult.Fail("Missing Authorization Header"));
         }
 
-        var authHeader = Request.Headers["Authorization"].ToString();
-        if (authHeader.StartsWith("Bearer ", System.StringComparison.OrdinalIgnoreCase))
+        return Task.FromResult(AuthenticateResult.Fail("The AuthenticationSecret was not correct!"));
+    }
+
+    private bool RequiresAuthentication()
+    {
+        var endpoint = Context.GetEndpoint();
+        var authorizeAttribute = endpoint?.Metadata?.GetMetadata<IAuthorizeData>();
+        return _authenticationSecret != null && authorizeAttribute != null;
+    }
+
+    private static bool TryGetBearerToken(string? authorizationHeader, out string token)
+    {
+        token = string.Empty;
+        if (string.IsNullOrWhiteSpace(authorizationHeader) ||
+            !authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
-            var token = authHeader.Substring("Bearer ".Length).Trim();
-
-            if (token == _authenticationSecret)
-            {
-                var claims = new[] { new Claim(ClaimTypes.NameIdentifier, "authenticatedUser") };
-                var identity = new ClaimsIdentity(claims, Scheme.Name);
-                var principal = new ClaimsPrincipal(identity);
-                var ticket = new AuthenticationTicket(principal, Scheme.Name);
-
-                return Task.FromResult(AuthenticateResult.Success(ticket));
-            }
-
-            return Task.FromResult(AuthenticateResult.Fail("The AuthenticationSecret was not correct!"));
+            return false;
         }
 
-        return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization Header"));
+        token = authorizationHeader["Bearer ".Length..].Trim();
+        return !string.IsNullOrWhiteSpace(token);
+    }
+
+    private AuthenticateResult CreateSuccessResult(string nameIdentifier)
+    {
+        var claims = new[] { new Claim(ClaimTypes.NameIdentifier, nameIdentifier) };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return AuthenticateResult.Success(ticket);
     }
 }

--- a/ImmichFrame.WebApi/ImmichFrame.WebApi.csproj
+++ b/ImmichFrame.WebApi/ImmichFrame.WebApi.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" />
     <PackageReference Include="YamlDotNet" />

--- a/ImmichFrame.WebApi/Models/AdminAuthDtos.cs
+++ b/ImmichFrame.WebApi/Models/AdminAuthDtos.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ImmichFrame.WebApi.Models;
+
+public class AdminAuthSessionDto
+{
+    public bool IsConfigured { get; set; }
+    public bool IsAuthenticated { get; set; }
+    public string? Username { get; set; }
+}
+
+public class AdminLoginRequest
+{
+    [Required]
+    public string Username { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+}

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -22,7 +22,7 @@ public class ClientSettingsDto
     public string? ImageLocationFormat { get; set; }
     public string? PrimaryColor { get; set; }
     public string? SecondaryColor { get; set; }
-    public string Style { get; set; }
+    public string Style { get; set; } = "none";
     public string? BaseFontSize { get; set; }
     public bool ShowWeatherDescription { get; set; }
     public string? WeatherIconUrl { get; set; }
@@ -30,8 +30,8 @@ public class ClientSettingsDto
     public bool ImagePan { get; set; }
     public bool ImageFill { get; set; }
     public bool PlayAudio { get; set; }
-    public string Layout { get; set; }
-    public string Language { get; set; }
+    public string Layout { get; set; } = "splitview";
+    public string Language { get; set; } = "en";
 
     public static ClientSettingsDto FromGeneralSettings(IGeneralSettings generalSettings)
     {

--- a/ImmichFrame.WebApi/Models/FrameSessionDtos.cs
+++ b/ImmichFrame.WebApi/Models/FrameSessionDtos.cs
@@ -63,6 +63,11 @@ public class FrameSessionStateDto : FrameSessionSnapshotDto
     public string? UserAgent { get; set; }
 }
 
+public class FrameSessionDisconnectRequest
+{
+    public string? AuthSecret { get; set; }
+}
+
 public class AdminCommandDto
 {
     public long CommandId { get; set; }

--- a/ImmichFrame.WebApi/Models/FrameSessionDtos.cs
+++ b/ImmichFrame.WebApi/Models/FrameSessionDtos.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Serialization;
+using ImmichFrame.Core.Api;
+
+namespace ImmichFrame.WebApi.Models;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum FramePlaybackState
+{
+    Playing,
+    Paused
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum FrameSessionStatus
+{
+    Active,
+    Stopped
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum FrameAdminCommandType
+{
+    Previous,
+    Play,
+    Pause,
+    Next,
+    Refresh,
+    Shutdown
+}
+
+public class DisplayedAssetDto
+{
+    public required string Id { get; set; }
+    public required string OriginalFileName { get; set; }
+    public AssetTypeEnum Type { get; set; }
+    public string? ImmichServerUrl { get; set; }
+    public string? LocalDateTime { get; set; }
+    public string? Description { get; set; }
+    public string? Thumbhash { get; set; }
+}
+
+public class DisplayEventDto
+{
+    public DateTimeOffset DisplayedAtUtc { get; set; }
+    public double? DurationSeconds { get; set; }
+    public List<DisplayedAssetDto> Assets { get; set; } = new();
+}
+
+public class FrameSessionSnapshotDto
+{
+    public FramePlaybackState PlaybackState { get; set; } = FramePlaybackState.Playing;
+    public FrameSessionStatus Status { get; set; } = FrameSessionStatus.Active;
+    public string? DisplayName { get; set; }
+    public DisplayEventDto? CurrentDisplay { get; set; }
+    public List<DisplayEventDto> History { get; set; } = new();
+}
+
+public class FrameSessionStateDto : FrameSessionSnapshotDto
+{
+    public required string ClientIdentifier { get; set; }
+    public DateTimeOffset ConnectedAtUtc { get; set; }
+    public DateTimeOffset LastSeenAtUtc { get; set; }
+    public string? UserAgent { get; set; }
+}
+
+public class AdminCommandDto
+{
+    public long CommandId { get; set; }
+    public FrameAdminCommandType CommandType { get; set; }
+    public DateTimeOffset IssuedAtUtc { get; set; }
+}
+
+public class EnqueueAdminCommandRequest
+{
+    public FrameAdminCommandType CommandType { get; set; }
+}
+
+public class UpdateFrameSessionDisplayNameRequest
+{
+    public string? DisplayName { get; set; }
+}

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -13,7 +13,7 @@ public class ServerSettings : IServerSettings, IConfigSettable
 
     [YamlMember(Alias = "Accounts")]
     [JsonPropertyName("Accounts")]
-    public IEnumerable<ServerAccountSettings> AccountsImpl { get; set; }
+    public IEnumerable<ServerAccountSettings> AccountsImpl { get; set; } = Array.Empty<ServerAccountSettings>();
 
     //Covariance not allowed on interface impls
     [JsonIgnore]

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -9,6 +9,7 @@ using ImmichFrame.WebApi.Helpers;
 using ImmichFrame.WebApi.Helpers.Config;
 using ImmichFrame.WebApi.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 using System.Threading.RateLimiting;
@@ -105,6 +106,10 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+});
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -175,6 +180,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseForwardedHeaders();
 app.UseStaticFiles();
 if (app.Environment.IsProduction())
 {

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -5,9 +5,28 @@ using Microsoft.AspNetCore.Authentication;
 using System.Reflection;
 using ImmichFrame.Core.Logic;
 using ImmichFrame.Core.Logic.AccountSelection;
+using ImmichFrame.WebApi.Helpers;
 using ImmichFrame.WebApi.Helpers.Config;
+using ImmichFrame.WebApi.Services;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using System.Security.Claims;
 
 var builder = WebApplication.CreateBuilder(args);
+
+if (builder.Environment.IsDevelopment())
+{
+    var root = Directory.GetCurrentDirectory();
+    var dotenv = Path.Combine(root, "..", "docker", ".env");
+
+    dotenv = Path.GetFullPath(dotenv);
+    DotEnv.Load(dotenv);
+}
+
+if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ASPNETCORE_URLS")))
+{
+    builder.WebHost.UseUrls("http://+:8080");
+}
+
 //log the version number
 var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
 Console.WriteLine($@"
@@ -67,16 +86,67 @@ builder.Services.AddTransient<Func<IAccountSettings, IAccountImmichFrameLogic>>(
     account => ActivatorUtilities.CreateInstance<PooledImmichFrameLogic>(srv, account));
 
 builder.Services.AddSingleton<IImmichFrameLogic, MultiImmichFrameLogicDelegate>();
+var appDataPath = Environment.GetEnvironmentVariable("IMMICHFRAME_APP_DATA_PATH") ??
+    Path.Combine(builder.Environment.ContentRootPath, "App_Data");
+builder.Services.AddSingleton(new FrameSessionRegistryOptions
+{
+    DisplayNameStorePath = Path.Combine(appDataPath, "frame-session-display-names.json")
+});
+builder.Services.AddSingleton<IFrameSessionRegistry>(srv =>
+    new FrameSessionRegistry(srv.GetRequiredService<FrameSessionRegistryOptions>(), null));
+builder.Services.AddSingleton<IAdminBasicAuthService, AdminBasicAuthService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddAuthorization(options => { options.AddPolicy("AllowAnonymous", policy => policy.RequireAssertion(context => true)); });
+builder.Services.AddAuthorization();
 
-builder.Services.AddAuthentication("ImmichFrameScheme")
-    .AddScheme<AuthenticationSchemeOptions, ImmichFrameAuthenticationHandler>("ImmichFrameScheme", options => { });
+builder.Services.AddAuthentication()
+    .AddScheme<AuthenticationSchemeOptions, ImmichFrameAuthenticationHandler>(AuthSchemes.Frame, options => { })
+    .AddCookie(AuthSchemes.Admin, options =>
+    {
+        options.Cookie.Name = "ImmichFrame.Admin";
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SameSite = SameSiteMode.Lax;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+        options.ExpireTimeSpan = TimeSpan.FromHours(12);
+        options.SlidingExpiration = true;
+        options.Events = new CookieAuthenticationEvents
+        {
+            OnValidatePrincipal = context =>
+            {
+                var adminBasicAuthService = context.HttpContext.RequestServices.GetRequiredService<IAdminBasicAuthService>();
+                var username = context.Principal?.FindFirstValue(ClaimTypes.Name);
+                var credentialVersion = context.Principal?.FindFirst("immichframe_admin_credential_version")?.Value;
+                var currentVersion = string.IsNullOrWhiteSpace(username)
+                    ? null
+                    : adminBasicAuthService.GetCredentialVersion(username);
+
+                if (string.IsNullOrWhiteSpace(username) ||
+                    string.IsNullOrWhiteSpace(credentialVersion) ||
+                    string.IsNullOrWhiteSpace(currentVersion) ||
+                    !string.Equals(credentialVersion, currentVersion, StringComparison.Ordinal))
+                {
+                    context.RejectPrincipal();
+                    return context.HttpContext.SignOutAsync(AuthSchemes.Admin);
+                }
+
+                return Task.CompletedTask;
+            },
+            OnRedirectToLogin = context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return Task.CompletedTask;
+            },
+            OnRedirectToAccessDenied = context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return Task.CompletedTask;
+            }
+        };
+    });
 
 var app = builder.Build();
 
@@ -87,23 +157,13 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+// app.UseHttpsRedirection();
+
 app.UseStaticFiles();
 if (app.Environment.IsProduction())
 {
     app.UseDefaultFiles();
 }
-
-if (app.Environment.IsDevelopment())
-{
-    var root = Directory.GetCurrentDirectory();
-    var dotenv = Path.Combine(root, "..", "docker", ".env");
-
-    dotenv = Path.GetFullPath(dotenv);
-    DotEnv.Load(dotenv);
-}
-
-// app.UseHttpsRedirection();
-app.UseMiddleware<CustomAuthenticationMiddleware>();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -9,7 +9,9 @@ using ImmichFrame.WebApi.Helpers;
 using ImmichFrame.WebApi.Helpers.Config;
 using ImmichFrame.WebApi.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
+using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -93,13 +95,29 @@ builder.Services.AddSingleton(new FrameSessionRegistryOptions
     DisplayNameStorePath = Path.Combine(appDataPath, "frame-session-display-names.json")
 });
 builder.Services.AddSingleton<IFrameSessionRegistry>(srv =>
-    new FrameSessionRegistry(srv.GetRequiredService<FrameSessionRegistryOptions>(), null));
+    new FrameSessionRegistry(
+        srv.GetRequiredService<FrameSessionRegistryOptions>(),
+        null,
+        srv.GetService<ILogger<FrameSessionRegistry>>()));
 builder.Services.AddSingleton<IAdminBasicAuthService, AdminBasicAuthService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy("AdminLogin", context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(5),
+                QueueLimit = 0
+            }));
+});
 
 builder.Services.AddAuthorization();
 
@@ -157,14 +175,13 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-// app.UseHttpsRedirection();
-
 app.UseStaticFiles();
 if (app.Environment.IsProduction())
 {
     app.UseDefaultFiles();
 }
 
+app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/ImmichFrame.WebApi/Services/AdminBasicAuthService.cs
+++ b/ImmichFrame.WebApi/Services/AdminBasicAuthService.cs
@@ -21,8 +21,13 @@ public class AdminBasicAuthService : IAdminBasicAuthService
     private readonly List<AdminBasicAuthUser> _users;
 
     public AdminBasicAuthService()
+        : this(Environment.GetEnvironmentVariables())
     {
-        _users = LoadUsers(Environment.GetEnvironmentVariables());
+    }
+
+    internal AdminBasicAuthService(IDictionary environmentVariables)
+    {
+        _users = LoadUsers(environmentVariables);
     }
 
     public bool HasUsers => _users.Count > 0;
@@ -106,6 +111,8 @@ public class AdminBasicAuthService : IAdminBasicAuthService
 
         if (hash.StartsWith("{SHA}", StringComparison.Ordinal))
         {
+            // "{SHA}" is the legacy htpasswd SHA1 format. Keep it only for compatibility and
+            // prefer stronger hashes such as bcrypt ("$2") or Apache MD5 ("$apr1$") in new configs.
             using var sha1 = SHA1.Create();
             var digest = sha1.ComputeHash(Encoding.UTF8.GetBytes(password));
             var computed = "{SHA}" + Convert.ToBase64String(digest);

--- a/ImmichFrame.WebApi/Services/AdminBasicAuthService.cs
+++ b/ImmichFrame.WebApi/Services/AdminBasicAuthService.cs
@@ -90,17 +90,44 @@ public class AdminBasicAuthService : IAdminBasicAuthService
             }
         }
 
-        return partialUsers.Values
-            .Where(x => !string.IsNullOrWhiteSpace(x.Username) && !string.IsNullOrWhiteSpace(x.Hash))
-            .Select(x => new AdminBasicAuthUser(x.Username!.Trim(), x.Hash!.Trim()))
-            .ToList();
+        var users = new List<AdminBasicAuthUser>();
+        var usernamesToSource = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var (sourceName, partialUser) in partialUsers)
+        {
+            if (string.IsNullOrWhiteSpace(partialUser.Username) || string.IsNullOrWhiteSpace(partialUser.Hash))
+            {
+                continue;
+            }
+
+            var username = partialUser.Username.Trim();
+            var hash = partialUser.Hash.Trim();
+
+            if (usernamesToSource.TryGetValue(username, out var existingSource))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate admin username '{username}' found in IMMICHFRAME_AUTH_BASIC_{existingSource}_USER and IMMICHFRAME_AUTH_BASIC_{sourceName}_USER.");
+            }
+
+            usernamesToSource[username] = sourceName;
+            users.Add(new AdminBasicAuthUser(username, hash));
+        }
+
+        return users;
     }
 
     private static bool VerifyPassword(string password, string hash)
     {
         if (hash.StartsWith("$2", StringComparison.Ordinal))
         {
-            return BCrypt.Net.BCrypt.Verify(password, hash);
+            try
+            {
+                return BCrypt.Net.BCrypt.Verify(password, hash);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         if (hash.StartsWith("$apr1$", StringComparison.Ordinal))

--- a/ImmichFrame.WebApi/Services/AdminBasicAuthService.cs
+++ b/ImmichFrame.WebApi/Services/AdminBasicAuthService.cs
@@ -1,0 +1,253 @@
+using System.Collections;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ImmichFrame.WebApi.Services;
+
+public interface IAdminBasicAuthService
+{
+    bool HasUsers { get; }
+    bool ValidateCredentials(string username, string password);
+    string? GetCredentialVersion(string username);
+}
+
+public class AdminBasicAuthService : IAdminBasicAuthService
+{
+    private static readonly Regex EnvironmentKeyPattern = new(
+        "^IMMICHFRAME_AUTH_BASIC_(?<name>[A-Z0-9_]+)_(?<kind>USER|HASH)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly List<AdminBasicAuthUser> _users;
+
+    public AdminBasicAuthService()
+    {
+        _users = LoadUsers(Environment.GetEnvironmentVariables());
+    }
+
+    public bool HasUsers => _users.Count > 0;
+
+    public bool ValidateCredentials(string username, string password)
+    {
+        foreach (var user in _users)
+        {
+            if (!string.Equals(user.Username, username, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return VerifyPassword(password, user.Hash);
+        }
+
+        return false;
+    }
+
+    public string? GetCredentialVersion(string username)
+    {
+        var user = _users.FirstOrDefault(x => string.Equals(x.Username, username, StringComparison.Ordinal));
+        return user == null ? null : ComputeCredentialVersion(user.Hash);
+    }
+
+    internal static List<AdminBasicAuthUser> LoadUsers(IDictionary environmentVariables)
+    {
+        var partialUsers = new Dictionary<string, PartialAdminBasicAuthUser>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (DictionaryEntry entry in environmentVariables)
+        {
+            var key = entry.Key?.ToString();
+            var value = entry.Value?.ToString();
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                continue;
+            }
+
+            var match = EnvironmentKeyPattern.Match(key);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var name = match.Groups["name"].Value;
+            var kind = match.Groups["kind"].Value;
+            if (!partialUsers.TryGetValue(name, out var partialUser))
+            {
+                partialUser = new PartialAdminBasicAuthUser();
+                partialUsers[name] = partialUser;
+            }
+
+            if (string.Equals(kind, "USER", StringComparison.OrdinalIgnoreCase))
+            {
+                partialUser.Username = value;
+            }
+            else if (string.Equals(kind, "HASH", StringComparison.OrdinalIgnoreCase))
+            {
+                partialUser.Hash = value;
+            }
+        }
+
+        return partialUsers.Values
+            .Where(x => !string.IsNullOrWhiteSpace(x.Username) && !string.IsNullOrWhiteSpace(x.Hash))
+            .Select(x => new AdminBasicAuthUser(x.Username!.Trim(), x.Hash!.Trim()))
+            .ToList();
+    }
+
+    private static bool VerifyPassword(string password, string hash)
+    {
+        if (hash.StartsWith("$2", StringComparison.Ordinal))
+        {
+            return BCrypt.Net.BCrypt.Verify(password, hash);
+        }
+
+        if (hash.StartsWith("$apr1$", StringComparison.Ordinal))
+        {
+            var computed = ApacheMd5Crypt.Hash(password, hash);
+            return FixedTimeEquals(computed, hash);
+        }
+
+        if (hash.StartsWith("{SHA}", StringComparison.Ordinal))
+        {
+            using var sha1 = SHA1.Create();
+            var digest = sha1.ComputeHash(Encoding.UTF8.GetBytes(password));
+            var computed = "{SHA}" + Convert.ToBase64String(digest);
+            return FixedTimeEquals(computed, hash);
+        }
+
+        return false;
+    }
+
+    private static bool FixedTimeEquals(string left, string right)
+    {
+        var leftBytes = Encoding.UTF8.GetBytes(left);
+        var rightBytes = Encoding.UTF8.GetBytes(right);
+        return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
+    }
+
+    private static string ComputeCredentialVersion(string hash)
+    {
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(hash));
+        return Convert.ToHexString(digest);
+    }
+
+    internal sealed record AdminBasicAuthUser(string Username, string Hash);
+
+    private sealed class PartialAdminBasicAuthUser
+    {
+        public string? Username { get; set; }
+        public string? Hash { get; set; }
+    }
+}
+
+internal static class ApacheMd5Crypt
+{
+    private const string Magic = "$apr1$";
+    private const string Itoa64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    public static string Hash(string password, string hashOrSalt)
+    {
+        var salt = ExtractSalt(hashOrSalt);
+        var passwordBytes = Encoding.UTF8.GetBytes(password);
+        var saltBytes = Encoding.UTF8.GetBytes(salt);
+
+        var initial = new List<byte>();
+        initial.AddRange(passwordBytes);
+        initial.AddRange(Encoding.ASCII.GetBytes(Magic));
+        initial.AddRange(saltBytes);
+
+        var alternate = Md5(passwordBytes, saltBytes, passwordBytes);
+        for (var remaining = passwordBytes.Length; remaining > 0; remaining -= 16)
+        {
+            initial.AddRange(alternate.Take(Math.Min(16, remaining)));
+        }
+
+        for (var length = passwordBytes.Length; length > 0; length >>= 1)
+        {
+            initial.Add((length & 1) == 1 ? (byte)0 : passwordBytes[0]);
+        }
+
+        var final = Md5(initial.ToArray());
+
+        for (var i = 0; i < 1000; i++)
+        {
+            var round = new List<byte>();
+
+            if ((i & 1) == 1)
+            {
+                round.AddRange(passwordBytes);
+            }
+            else
+            {
+                round.AddRange(final);
+            }
+
+            if (i % 3 != 0)
+            {
+                round.AddRange(saltBytes);
+            }
+
+            if (i % 7 != 0)
+            {
+                round.AddRange(passwordBytes);
+            }
+
+            if ((i & 1) == 1)
+            {
+                round.AddRange(final);
+            }
+            else
+            {
+                round.AddRange(passwordBytes);
+            }
+
+            final = Md5(round.ToArray());
+        }
+
+        var encoded = string.Concat(
+            To64((final[0] << 16) | (final[6] << 8) | final[12], 4),
+            To64((final[1] << 16) | (final[7] << 8) | final[13], 4),
+            To64((final[2] << 16) | (final[8] << 8) | final[14], 4),
+            To64((final[3] << 16) | (final[9] << 8) | final[15], 4),
+            To64((final[4] << 16) | (final[10] << 8) | final[5], 4),
+            To64(final[11], 2));
+
+        return $"{Magic}{salt}${encoded}";
+    }
+
+    private static byte[] Md5(params byte[][] buffers)
+    {
+        using var md5 = MD5.Create();
+        foreach (var buffer in buffers)
+        {
+            md5.TransformBlock(buffer, 0, buffer.Length, null, 0);
+        }
+
+        md5.TransformFinalBlock([], 0, 0);
+        return md5.Hash ?? [];
+    }
+
+    private static string ExtractSalt(string hashOrSalt)
+    {
+        var value = hashOrSalt.StartsWith(Magic, StringComparison.Ordinal)
+            ? hashOrSalt[Magic.Length..]
+            : hashOrSalt;
+
+        var dollarIndex = value.IndexOf('$');
+        if (dollarIndex >= 0)
+        {
+            value = value[..dollarIndex];
+        }
+
+        return value.Length > 8 ? value[..8] : value;
+    }
+
+    private static string To64(int value, int length)
+    {
+        var builder = new StringBuilder(length);
+        while (length-- > 0)
+        {
+            builder.Append(Itoa64[value & 0x3f]);
+            value >>= 6;
+        }
+
+        return builder.ToString();
+    }
+}

--- a/ImmichFrame.WebApi/Services/AuthSchemes.cs
+++ b/ImmichFrame.WebApi/Services/AuthSchemes.cs
@@ -1,0 +1,7 @@
+namespace ImmichFrame.WebApi.Services;
+
+public static class AuthSchemes
+{
+    public const string Frame = "ImmichFrameScheme";
+    public const string Admin = "ImmichFrameAdminScheme";
+}

--- a/ImmichFrame.WebApi/Services/FrameSessionRegistry.cs
+++ b/ImmichFrame.WebApi/Services/FrameSessionRegistry.cs
@@ -65,7 +65,7 @@ public class FrameSessionRegistry : IFrameSessionRegistry
                 ApplyDisplayNameUnsafe(session, NormalizeDisplayName(snapshot.DisplayName), persistWhenProvided: true);
             }
             session.CurrentDisplay = CloneDisplayEvent(snapshot.CurrentDisplay);
-            session.History = snapshot.History
+            session.History = (snapshot.History ?? Enumerable.Empty<DisplayEventDto>())
                 .Take(_options.MaxHistoryItems)
                 .Select(CloneDisplayEvent)
                 .Where(x => x != null)

--- a/ImmichFrame.WebApi/Services/FrameSessionRegistry.cs
+++ b/ImmichFrame.WebApi/Services/FrameSessionRegistry.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using ImmichFrame.WebApi.Models;
+using Microsoft.Extensions.Logging;
 
 namespace ImmichFrame.WebApi.Services;
 
@@ -18,17 +19,19 @@ public class FrameSessionRegistry : IFrameSessionRegistry
     private readonly object _sync = new();
     private readonly Func<DateTimeOffset> _utcNow;
     private readonly FrameSessionRegistryOptions _options;
+    private readonly ILogger<FrameSessionRegistry>? _logger;
     private long _nextCommandId;
 
     public FrameSessionRegistry()
-        : this(new FrameSessionRegistryOptions(), null)
+        : this(new FrameSessionRegistryOptions(), null, null)
     {
     }
 
-    internal FrameSessionRegistry(FrameSessionRegistryOptions options, Func<DateTimeOffset>? utcNow)
+    internal FrameSessionRegistry(FrameSessionRegistryOptions options, Func<DateTimeOffset>? utcNow, ILogger<FrameSessionRegistry>? logger = null)
     {
         _options = options;
         _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+        _logger = logger;
         LoadPersistedDisplayNames();
     }
 
@@ -132,7 +135,7 @@ public class FrameSessionRegistry : IFrameSessionRegistry
         }
     }
 
-    public AdminCommandDto? EnqueueCommand(string clientIdentifier, FrameAdminCommandType commandType)
+    public FrameSessionCommandEnqueueResult EnqueueCommand(string clientIdentifier, FrameAdminCommandType commandType)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(clientIdentifier);
 
@@ -143,23 +146,33 @@ public class FrameSessionRegistry : IFrameSessionRegistry
 
             if (!_sessions.TryGetValue(clientIdentifier, out var session))
             {
-                return null;
+                return new FrameSessionCommandEnqueueResult
+                {
+                    Status = FrameSessionCommandEnqueueStatus.NotFound
+                };
             }
 
             if (session.Status != FrameSessionStatus.Active || now - session.LastSeenAtUtc > _options.HeartbeatTtl)
             {
-                return null;
+                return new FrameSessionCommandEnqueueResult
+                {
+                    Status = FrameSessionCommandEnqueueStatus.Stale
+                };
             }
 
             var command = new AdminCommandDto
             {
-                CommandId = Interlocked.Increment(ref _nextCommandId),
+                CommandId = ++_nextCommandId,
                 CommandType = commandType,
                 IssuedAtUtc = now
             };
 
             session.PendingCommands.Add(command);
-            return CloneCommand(command);
+            return new FrameSessionCommandEnqueueResult
+            {
+                Status = FrameSessionCommandEnqueueStatus.Enqueued,
+                Command = CloneCommand(command)
+            };
         }
     }
 
@@ -246,7 +259,9 @@ public class FrameSessionRegistry : IFrameSessionRegistry
         {
             DisplayedAtUtc = displayEvent.DisplayedAtUtc,
             DurationSeconds = displayEvent.DurationSeconds,
-            Assets = displayEvent.Assets.Select(CloneDisplayedAsset).ToList()
+            Assets = (displayEvent.Assets ?? Enumerable.Empty<DisplayedAssetDto>())
+                .Select(CloneDisplayedAsset)
+                .ToList()
         };
     }
 
@@ -324,9 +339,9 @@ public class FrameSessionRegistry : IFrameSessionRegistry
                 }
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore a corrupted name-store file and continue with an empty in-memory cache.
+            _logger?.LogWarning(ex, "Failed to load name-store file, continuing with empty in-memory cache.");
         }
     }
 

--- a/ImmichFrame.WebApi/Services/FrameSessionRegistry.cs
+++ b/ImmichFrame.WebApi/Services/FrameSessionRegistry.cs
@@ -1,0 +1,367 @@
+using System.Text.Json;
+using ImmichFrame.WebApi.Models;
+
+namespace ImmichFrame.WebApi.Services;
+
+public class FrameSessionRegistryOptions
+{
+    public TimeSpan HeartbeatTtl { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan StaleSessionTtl { get; init; } = TimeSpan.FromMinutes(5);
+    public int MaxHistoryItems { get; init; } = 50;
+    public string? DisplayNameStorePath { get; init; }
+}
+
+public class FrameSessionRegistry : IFrameSessionRegistry
+{
+    private readonly Dictionary<string, FrameSessionRecord> _sessions = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _persistedDisplayNames = new(StringComparer.Ordinal);
+    private readonly object _sync = new();
+    private readonly Func<DateTimeOffset> _utcNow;
+    private readonly FrameSessionRegistryOptions _options;
+    private long _nextCommandId;
+
+    public FrameSessionRegistry()
+        : this(new FrameSessionRegistryOptions(), null)
+    {
+    }
+
+    internal FrameSessionRegistry(FrameSessionRegistryOptions options, Func<DateTimeOffset>? utcNow)
+    {
+        _options = options;
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+        LoadPersistedDisplayNames();
+    }
+
+    public void UpsertSnapshot(string clientIdentifier, FrameSessionSnapshotDto snapshot, string? userAgent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientIdentifier);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            if (!_sessions.TryGetValue(clientIdentifier, out var session))
+            {
+                session = new FrameSessionRecord
+                {
+                    ClientIdentifier = clientIdentifier,
+                    ConnectedAtUtc = now,
+                    DisplayName = _persistedDisplayNames.GetValueOrDefault(clientIdentifier)
+                };
+                _sessions[clientIdentifier] = session;
+            }
+
+            session.LastSeenAtUtc = now;
+            session.UserAgent = string.IsNullOrWhiteSpace(userAgent) ? session.UserAgent : userAgent;
+            session.PlaybackState = snapshot.PlaybackState;
+            session.Status = snapshot.Status;
+            if (!string.IsNullOrWhiteSpace(snapshot.DisplayName))
+            {
+                ApplyDisplayNameUnsafe(session, NormalizeDisplayName(snapshot.DisplayName), persistWhenProvided: true);
+            }
+            session.CurrentDisplay = CloneDisplayEvent(snapshot.CurrentDisplay);
+            session.History = snapshot.History
+                .Take(_options.MaxHistoryItems)
+                .Select(CloneDisplayEvent)
+                .Where(x => x != null)
+                .Cast<DisplayEventDto>()
+                .ToList();
+        }
+    }
+
+    public IReadOnlyList<AdminCommandDto> GetPendingCommands(string clientIdentifier)
+    {
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            if (!_sessions.TryGetValue(clientIdentifier, out var session))
+            {
+                return Array.Empty<AdminCommandDto>();
+            }
+
+            return session.PendingCommands.Select(CloneCommand).ToList();
+        }
+    }
+
+    public bool AcknowledgeCommand(string clientIdentifier, long commandId)
+    {
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            if (!_sessions.TryGetValue(clientIdentifier, out var session))
+            {
+                return false;
+            }
+
+            var removed = session.PendingCommands.RemoveAll(command => command.CommandId <= commandId);
+            return removed > 0;
+        }
+    }
+
+    public bool MarkStopped(string clientIdentifier, string? userAgent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientIdentifier);
+
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            if (!_sessions.TryGetValue(clientIdentifier, out var session))
+            {
+                session = new FrameSessionRecord
+                {
+                    ClientIdentifier = clientIdentifier,
+                    ConnectedAtUtc = now,
+                    DisplayName = _persistedDisplayNames.GetValueOrDefault(clientIdentifier)
+                };
+                _sessions[clientIdentifier] = session;
+            }
+
+            session.LastSeenAtUtc = now;
+            session.Status = FrameSessionStatus.Stopped;
+            session.PlaybackState = FramePlaybackState.Paused;
+            session.UserAgent = string.IsNullOrWhiteSpace(userAgent) ? session.UserAgent : userAgent;
+            return true;
+        }
+    }
+
+    public AdminCommandDto? EnqueueCommand(string clientIdentifier, FrameAdminCommandType commandType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientIdentifier);
+
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            if (!_sessions.TryGetValue(clientIdentifier, out var session))
+            {
+                return null;
+            }
+
+            if (session.Status != FrameSessionStatus.Active || now - session.LastSeenAtUtc > _options.HeartbeatTtl)
+            {
+                return null;
+            }
+
+            var command = new AdminCommandDto
+            {
+                CommandId = Interlocked.Increment(ref _nextCommandId),
+                CommandType = commandType,
+                IssuedAtUtc = now
+            };
+
+            session.PendingCommands.Add(command);
+            return CloneCommand(command);
+        }
+    }
+
+    public bool UpdateDisplayName(string clientIdentifier, string? displayName)
+    {
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            if (!_sessions.TryGetValue(clientIdentifier, out var session))
+            {
+                return false;
+            }
+
+            ApplyDisplayNameUnsafe(session, NormalizeDisplayName(displayName), persistWhenProvided: true);
+            return true;
+        }
+    }
+
+    public IReadOnlyList<FrameSessionStateDto> GetActiveSessions()
+    {
+        var now = _utcNow();
+        lock (_sync)
+        {
+            PruneUnsafe(now);
+
+            return _sessions.Values
+                .Where(session => session.Status == FrameSessionStatus.Active)
+                .Where(session => now - session.LastSeenAtUtc <= _options.HeartbeatTtl)
+                .OrderByDescending(session => session.LastSeenAtUtc)
+                .Select(CloneSession)
+                .ToList();
+        }
+    }
+
+    private void PruneUnsafe(DateTimeOffset now)
+    {
+        var expiredKeys = _sessions
+            .Where(entry => now - entry.Value.LastSeenAtUtc > _options.StaleSessionTtl)
+            .Select(entry => entry.Key)
+            .ToList();
+
+        foreach (var key in expiredKeys)
+        {
+            _sessions.Remove(key);
+        }
+    }
+
+    private static FrameSessionStateDto CloneSession(FrameSessionRecord session)
+    {
+        return new FrameSessionStateDto
+        {
+            ClientIdentifier = session.ClientIdentifier,
+            ConnectedAtUtc = session.ConnectedAtUtc,
+            LastSeenAtUtc = session.LastSeenAtUtc,
+            UserAgent = session.UserAgent,
+            DisplayName = session.DisplayName,
+            PlaybackState = session.PlaybackState,
+            Status = session.Status,
+            CurrentDisplay = CloneDisplayEvent(session.CurrentDisplay),
+            History = session.History.Select(CloneDisplayEvent).Where(x => x != null).Cast<DisplayEventDto>().ToList()
+        };
+    }
+
+    private static AdminCommandDto CloneCommand(AdminCommandDto command)
+    {
+        return new AdminCommandDto
+        {
+            CommandId = command.CommandId,
+            CommandType = command.CommandType,
+            IssuedAtUtc = command.IssuedAtUtc
+        };
+    }
+
+    private static DisplayEventDto? CloneDisplayEvent(DisplayEventDto? displayEvent)
+    {
+        if (displayEvent == null)
+        {
+            return null;
+        }
+
+        return new DisplayEventDto
+        {
+            DisplayedAtUtc = displayEvent.DisplayedAtUtc,
+            DurationSeconds = displayEvent.DurationSeconds,
+            Assets = displayEvent.Assets.Select(CloneDisplayedAsset).ToList()
+        };
+    }
+
+    private static DisplayedAssetDto CloneDisplayedAsset(DisplayedAssetDto asset)
+    {
+        return new DisplayedAssetDto
+        {
+            Id = asset.Id,
+            OriginalFileName = asset.OriginalFileName,
+            Type = asset.Type,
+            ImmichServerUrl = asset.ImmichServerUrl,
+            LocalDateTime = asset.LocalDateTime,
+            Description = asset.Description,
+            Thumbhash = asset.Thumbhash
+        };
+    }
+
+    private static string? NormalizeDisplayName(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return null;
+        }
+
+        return displayName.Trim();
+    }
+
+    private void ApplyDisplayNameUnsafe(FrameSessionRecord session, string? displayName, bool persistWhenProvided)
+    {
+        if (displayName == null)
+        {
+            if (persistWhenProvided)
+            {
+                session.DisplayName = null;
+                _persistedDisplayNames.Remove(session.ClientIdentifier);
+                SavePersistedDisplayNamesUnsafe();
+            }
+
+            return;
+        }
+
+        session.DisplayName = displayName;
+        if (!persistWhenProvided)
+        {
+            return;
+        }
+
+        _persistedDisplayNames[session.ClientIdentifier] = displayName;
+        SavePersistedDisplayNamesUnsafe();
+    }
+
+    private void LoadPersistedDisplayNames()
+    {
+        var path = _options.DisplayNameStorePath;
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            var values = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            if (values == null)
+            {
+                return;
+            }
+
+            foreach (var entry in values)
+            {
+                var normalizedName = NormalizeDisplayName(entry.Value);
+                if (!string.IsNullOrWhiteSpace(entry.Key) && normalizedName != null)
+                {
+                    _persistedDisplayNames[entry.Key] = normalizedName;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore a corrupted name-store file and continue with an empty in-memory cache.
+        }
+    }
+
+    private void SavePersistedDisplayNamesUnsafe()
+    {
+        var path = _options.DisplayNameStorePath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(_persistedDisplayNames, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+        File.WriteAllText(path, json);
+    }
+
+    private sealed class FrameSessionRecord
+    {
+        public required string ClientIdentifier { get; init; }
+        public DateTimeOffset ConnectedAtUtc { get; set; }
+        public DateTimeOffset LastSeenAtUtc { get; set; }
+        public string? UserAgent { get; set; }
+        public string? DisplayName { get; set; }
+        public FramePlaybackState PlaybackState { get; set; } = FramePlaybackState.Playing;
+        public FrameSessionStatus Status { get; set; } = FrameSessionStatus.Active;
+        public DisplayEventDto? CurrentDisplay { get; set; }
+        public List<DisplayEventDto> History { get; set; } = new();
+        public List<AdminCommandDto> PendingCommands { get; } = new();
+    }
+}

--- a/ImmichFrame.WebApi/Services/IFrameSessionRegistry.cs
+++ b/ImmichFrame.WebApi/Services/IFrameSessionRegistry.cs
@@ -1,0 +1,14 @@
+using ImmichFrame.WebApi.Models;
+
+namespace ImmichFrame.WebApi.Services;
+
+public interface IFrameSessionRegistry
+{
+    void UpsertSnapshot(string clientIdentifier, FrameSessionSnapshotDto snapshot, string? userAgent);
+    IReadOnlyList<AdminCommandDto> GetPendingCommands(string clientIdentifier);
+    bool AcknowledgeCommand(string clientIdentifier, long commandId);
+    bool MarkStopped(string clientIdentifier, string? userAgent);
+    AdminCommandDto? EnqueueCommand(string clientIdentifier, FrameAdminCommandType commandType);
+    bool UpdateDisplayName(string clientIdentifier, string? displayName);
+    IReadOnlyList<FrameSessionStateDto> GetActiveSessions();
+}

--- a/ImmichFrame.WebApi/Services/IFrameSessionRegistry.cs
+++ b/ImmichFrame.WebApi/Services/IFrameSessionRegistry.cs
@@ -2,13 +2,26 @@ using ImmichFrame.WebApi.Models;
 
 namespace ImmichFrame.WebApi.Services;
 
+public enum FrameSessionCommandEnqueueStatus
+{
+    Enqueued,
+    NotFound,
+    Stale
+}
+
+public class FrameSessionCommandEnqueueResult
+{
+    public required FrameSessionCommandEnqueueStatus Status { get; init; }
+    public AdminCommandDto? Command { get; init; }
+}
+
 public interface IFrameSessionRegistry
 {
     void UpsertSnapshot(string clientIdentifier, FrameSessionSnapshotDto snapshot, string? userAgent);
     IReadOnlyList<AdminCommandDto> GetPendingCommands(string clientIdentifier);
     bool AcknowledgeCommand(string clientIdentifier, long commandId);
     bool MarkStopped(string clientIdentifier, string? userAgent);
-    AdminCommandDto? EnqueueCommand(string clientIdentifier, FrameAdminCommandType commandType);
+    FrameSessionCommandEnqueueResult EnqueueCommand(string clientIdentifier, FrameAdminCommandType commandType);
     bool UpdateDisplayName(string clientIdentifier, string? displayName);
     IReadOnlyList<FrameSessionStateDto> GetActiveSessions();
 }

--- a/Install_Web.md
+++ b/Install_Web.md
@@ -128,6 +128,10 @@ services:
 
 For more information, read [here](/README.md#configuration).
 
+The frame UI and the admin dashboard are both available on `http://HOST:8080`, with the admin dashboard at `http://HOST:8080/admin`.
+
+To enable the admin login page, add at least one matching `IMMICHFRAME_AUTH_BASIC_*_USER` and `IMMICHFRAME_AUTH_BASIC_*_HASH` pair to your environment or `.env` file. These env values remain the source of truth for admin users, and the `/admin` page signs in against them with a normal session cookie.
+
 ## 🆘 Help
 
 [Discord Channel][support-url]

--- a/Install_Web.md
+++ b/Install_Web.md
@@ -132,6 +132,8 @@ The frame UI and the admin dashboard are both available on `http://HOST:8080`, w
 
 To enable the admin login page, add at least one matching `IMMICHFRAME_AUTH_BASIC_*_USER` and `IMMICHFRAME_AUTH_BASIC_*_HASH` pair to your environment or `.env` file. These env values remain the source of truth for admin users, and the `/admin` page signs in against them with a normal session cookie.
 
+If `/admin` is reachable outside a trusted local network, only expose it over HTTPS or behind a TLS-terminating reverse proxy such as Nginx or Traefik. The admin login uses environment-backed credentials and session cookies, and both can be intercepted if the endpoint is exposed over plain HTTP.
+
 ## 🆘 Help
 
 [Discord Channel][support-url]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -9,3 +9,4 @@ services:
       - .env
     # volumes:
       # - PATH/TO/CONFIG:/app/Config
+      # - PATH/TO/APPDATA:/app/App_Data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: on-failure
     # volumes:
     #   - PATH/TO/CONFIG:/app/Config
+    #   - PATH/TO/APPDATA:/app/App_Data
     #   - PATH/TO/CUSTOMCSS/custom.css:/app/wwwroot/static/custom.css
     ports:
       - "8080:8080"

--- a/docker/example.env
+++ b/docker/example.env
@@ -5,6 +5,9 @@ ApiKey=KEY
 # ApiKeyFile=/path/to/key
 
 # AuthenticationSecret=
+# Admin login users are read from these htpasswd-style env vars and used by the /admin login page.
+# IMMICHFRAME_AUTH_BASIC_ADMIN_USER=admin
+# IMMICHFRAME_AUTH_BASIC_ADMIN_HASH=$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/
 # Interval=10
 # TransitionDuration=2
 # ImageZoom=true

--- a/immichFrame.Web/package-lock.json
+++ b/immichFrame.Web/package-lock.json
@@ -105,7 +105,6 @@
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -1303,7 +1302,6 @@
 			"integrity": "sha512-iAIPEahFgDJJyvz8g0jP08KvqnM6JvdW8YfsygZ+pMeMvyM2zssWMltcsotETvjSZ82G3VlitgDtBIvpQSZrTA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1346,7 +1344,6 @@
 			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"deepmerge": "^4.3.1",
@@ -1464,7 +1461,6 @@
 			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.56.1",
 				"@typescript-eslint/types": "8.56.1",
@@ -1708,7 +1704,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1941,7 +1936,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2267,7 +2261,6 @@
 			"integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -2866,7 +2859,6 @@
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -3209,8 +3201,7 @@
 			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
 			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -3315,7 +3306,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3363,7 +3353,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3588,7 +3577,6 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -3935,7 +3923,6 @@
 			"integrity": "sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4318,7 +4305,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4405,7 +4391,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -2,7 +2,11 @@
 	import * as api from '$lib/index';
 	import ProgressBar from '$lib/components/elements/progress-bar.svelte';
 	import { slideshowStore } from '$lib/stores/slideshow.store';
-	import { clientIdentifierStore, authSecretStore } from '$lib/stores/persist.store';
+	import {
+		clientIdentifierStore,
+		clientNameStore,
+		authSecretStore
+	} from '$lib/stores/persist.store';
 	import { onDestroy, onMount, setContext, tick } from 'svelte';
 	import OverlayControls from '../elements/overlay-controls.svelte';
 	import AssetComponent from '../elements/asset-component.svelte';
@@ -15,6 +19,12 @@
 	import { page } from '$app/state';
 	import { ProgressBarLocation, ProgressBarStatus } from '../elements/progress-bar.types';
 	import { isImageAsset, isVideoAsset } from '$lib/constants/asset-type';
+	import {
+		acknowledgeFrameSessionCommand,
+		disconnectFrameSession,
+		getFrameSessionCommands,
+		putFrameSessionSnapshot
+	} from '$lib/frameSessionApi';
 
 	interface AssetsState {
 		assets: [string, api.AssetResponseDto, api.AlbumResponseDto[]][];
@@ -24,15 +34,28 @@
 		hasBday: boolean;
 	}
 
+	interface SessionDisplayEvent {
+		displayedAtUtc: string;
+		durationSeconds: number;
+		assets: api.AssetResponseDto[];
+	}
+
 	api.init();
 
-	// TODO: make this configurable?
 	const PRELOAD_ASSETS = 5;
+	const HEARTBEAT_INTERVAL_MS = 10_000;
+	const COMMAND_POLL_INTERVAL_MS = 2_000;
+	const MAX_DISPLAY_HISTORY = 50;
 
 	let assetHistory: api.AssetResponseDto[] = [];
 	let assetBacklog: api.AssetResponseDto[] = [];
+	let displayEventHistory: SessionDisplayEvent[] = [];
 
 	let displayingAssets: api.AssetResponseDto[] = $state([]);
+	let currentDisplayStartedAt: string | null = $state(null);
+	let currentDisplayDurationSeconds: number = $state($configStore.interval ?? 20);
+	let currentDisplayPausedAtMs: number | null = $state(null);
+	let adminStopped: boolean = $state(false);
 
 	const { restartProgress, stopProgress, instantTransition } = slideshowStore;
 
@@ -63,12 +86,21 @@
 
 	let cursorVisible = $state(true);
 	let timeoutId: number;
+	let heartbeatIntervalId: number | undefined;
+	let commandPollIntervalId: number | undefined;
+	let isPollingCommands = false;
+	let isHandlingRemoteCommand = false;
 
 	const clientIdentifier = page.url.searchParams.get('client');
+	const clientName = page.url.searchParams.get('name');
 	const authsecret = page.url.searchParams.get('authsecret');
 
 	if (clientIdentifier && clientIdentifier != $clientIdentifierStore) {
 		clientIdentifierStore.set(clientIdentifier);
+	}
+
+	if (clientName && clientName != $clientNameStore) {
+		clientNameStore.set(clientName);
 	}
 
 	if (authsecret && authsecret != $authSecretStore) {
@@ -83,10 +115,7 @@
 	setContext('close', provideClose);
 
 	async function provideClose() {
-		infoVisible = false;
-		userPaused = false;
-		await assetComponent?.play?.();
-		await progressBar.play();
+		await resumePlayback();
 	}
 
 	const showCursor = () => {
@@ -94,6 +123,128 @@
 		clearTimeout(timeoutId);
 		timeoutId = setTimeout(hideCursor, 2000);
 	};
+
+	function toSessionDisplayEvent(
+		assets: api.AssetResponseDto[],
+		displayedAtUtc: string,
+		durationSeconds: number
+	): SessionDisplayEvent {
+		return {
+			displayedAtUtc,
+			durationSeconds,
+			assets: [...assets]
+		};
+	}
+
+	function archiveCurrentDisplay() {
+		if (!displayingAssets.length || !currentDisplayStartedAt) {
+			return;
+		}
+
+		displayEventHistory = [
+			toSessionDisplayEvent(displayingAssets, currentDisplayStartedAt, currentDisplayDurationSeconds),
+			...displayEventHistory
+		].slice(0, MAX_DISPLAY_HISTORY);
+	}
+
+	function setCurrentDisplay(assets: api.AssetResponseDto[]) {
+		currentDisplayStartedAt = assets.length ? new Date().toISOString() : null;
+		currentDisplayPausedAtMs = null;
+	}
+
+	function pauseCurrentDisplayClock() {
+		if (currentDisplayPausedAtMs == null) {
+			currentDisplayPausedAtMs = Date.now();
+		}
+	}
+
+	function resumeCurrentDisplayClock() {
+		if (currentDisplayPausedAtMs == null || !currentDisplayStartedAt) {
+			currentDisplayPausedAtMs = null;
+			return;
+		}
+
+		const pausedDurationMs = Date.now() - currentDisplayPausedAtMs;
+		currentDisplayStartedAt = new Date(
+			new Date(currentDisplayStartedAt).getTime() + pausedDurationMs
+		).toISOString();
+		currentDisplayPausedAtMs = null;
+	}
+
+	function toDisplayedAssetDto(asset: api.AssetResponseDto) {
+		return {
+			id: asset.id,
+			originalFileName: asset.originalFileName,
+			type: asset.type,
+			immichServerUrl: asset.immichServerUrl ?? null,
+			localDateTime: asset.localDateTime,
+			description: asset.exifInfo?.description ?? null,
+			thumbhash: asset.thumbhash ?? null
+		};
+	}
+
+	function buildCurrentDisplay() {
+		if (!displayingAssets.length || !currentDisplayStartedAt) {
+			return null;
+		}
+
+		return {
+			displayedAtUtc: currentDisplayStartedAt,
+			durationSeconds: currentDisplayDurationSeconds,
+			assets: displayingAssets.map(toDisplayedAssetDto)
+		};
+	}
+
+	function buildHistory() {
+		return displayEventHistory.map((displayEvent) => ({
+			displayedAtUtc: displayEvent.displayedAtUtc,
+			durationSeconds: displayEvent.durationSeconds,
+			assets: displayEvent.assets.map(toDisplayedAssetDto)
+		}));
+	}
+
+	async function syncFrameSession(status: 'Active' | 'Stopped' = adminStopped ? 'Stopped' : 'Active') {
+		if (!$clientIdentifierStore) {
+			return;
+		}
+
+		try {
+			await putFrameSessionSnapshot($clientIdentifierStore, {
+				playbackState:
+					adminStopped || progressBarStatus === ProgressBarStatus.Paused ? 'Paused' : 'Playing',
+				status,
+				displayName: $clientNameStore,
+				currentDisplay: buildCurrentDisplay(),
+				history: buildHistory()
+			});
+		} catch (err) {
+			console.warn('Failed to sync frame session:', err);
+		}
+	}
+
+	function startSessionLoops() {
+		stopSessionLoops();
+
+		heartbeatIntervalId = window.setInterval(() => {
+			void syncFrameSession();
+		}, HEARTBEAT_INTERVAL_MS);
+
+		commandPollIntervalId = window.setInterval(() => {
+			void processPendingCommands();
+		}, COMMAND_POLL_INTERVAL_MS);
+	}
+
+	function stopSessionLoops() {
+		if (heartbeatIntervalId) {
+			clearInterval(heartbeatIntervalId);
+			heartbeatIntervalId = undefined;
+		}
+
+		if (commandPollIntervalId) {
+			clearInterval(commandPollIntervalId);
+			commandPollIntervalId = undefined;
+		}
+	}
 
 	async function updateAssetPromises() {
 		for (let asset of displayingAssets) {
@@ -109,7 +260,6 @@
 				assetPromisesDict[assetBacklog[i].id] = loadAsset(assetBacklog[i]);
 			}
 		}
-		// Collect keys to remove first to avoid modifying dict during async iteration
 		const keysToRemove = Object.keys(assetPromisesDict).filter(
 			(key) =>
 				!displayingAssets.find((item) => item.id === key) &&
@@ -128,6 +278,10 @@
 	}
 
 	async function loadAssets() {
+		if (adminStopped) {
+			return;
+		}
+
 		try {
 			let assetRequest = await api.getAssets();
 
@@ -150,7 +304,7 @@
 
 	let isHandlingAssetTransition = false;
 	const handleDone = async (previous: boolean = false, instant: boolean = false) => {
-		if (isHandlingAssetTransition) {
+		if (isHandlingAssetTransition || adminStopped) {
 			return;
 		}
 		isHandlingAssetTransition = true;
@@ -162,7 +316,8 @@
 			else await getNextAssets();
 			await tick();
 			await assetComponent?.play?.();
-			progressBar.play();
+			void progressBar.play();
+			await syncFrameSession();
 		} finally {
 			isHandlingAssetTransition = false;
 		}
@@ -185,6 +340,7 @@
 
 		if (displayingAssets.length) {
 			assetHistory.push(...displayingAssets);
+			archiveCurrentDisplay();
 		}
 
 		if (assetHistory.length > 250) {
@@ -192,8 +348,10 @@
 		}
 
 		displayingAssets = next;
+		setCurrentDisplay(next);
 		await updateAssetPromises();
 		assetsState = await pickAssets(next);
+		currentDisplayDurationSeconds = currentDuration;
 	}
 
 	async function getPreviousAssets() {
@@ -207,11 +365,14 @@
 
 		if (displayingAssets.length) {
 			assetBacklog.unshift(...displayingAssets);
+			archiveCurrentDisplay();
 		}
 
 		displayingAssets = next;
+		setCurrentDisplay(next);
 		await updateAssetPromises();
 		assetsState = await pickAssets(next);
+		currentDisplayDurationSeconds = currentDuration;
 	}
 
 	function isPortrait(asset: api.AssetResponseDto) {
@@ -284,7 +445,7 @@
 			return 0;
 		}
 
-		const multipliers = [3600, 60, 1]; // hours, minutes, seconds
+		const multipliers = [3600, 60, 1];
 		const offset = multipliers.length - parts.length;
 
 		let total = 0;
@@ -329,14 +490,12 @@
 		let assetUrl: string;
 
 		if (isVideoAsset(assetResponse)) {
-			// Stream videos directly instead of preloading
 			assetUrl = api.getAssetStreamUrl(
 				assetResponse.id,
 				$clientIdentifierStore,
 				assetResponse.type
 			);
 		} else {
-			// Preload images as blobs
 			const req = await api.getAsset(assetResponse.id, {
 				clientIdentifier: $clientIdentifierStore,
 				assetType: assetResponse.type
@@ -355,7 +514,6 @@
 			album = albumReq.data ?? [];
 		}
 
-		// if the people array is already populated, there is no need to call the API again
 		if ($configStore.showPeopleDesc && (assetResponse.people ?? []).length == 0) {
 			const assetInfoRequest = await api.getAssetInfo(assetResponse.id, {
 				clientIdentifier: $clientIdentifierStore
@@ -375,7 +533,6 @@
 	}
 
 	function revokeObjectUrl(url: string) {
-		// Only revoke blob URLs, not streaming URLs
 		if (!url.startsWith('blob:')) return;
 		try {
 			URL.revokeObjectURL(url);
@@ -384,9 +541,128 @@
 		}
 	}
 
+	async function resumePlayback() {
+		if (adminStopped) {
+			return;
+		}
+
+		infoVisible = false;
+		userPaused = false;
+		resumeCurrentDisplayClock();
+		await assetComponent?.play?.();
+		void progressBar.play();
+		await syncFrameSession();
+	}
+
+	async function pausePlayback() {
+		if (adminStopped) {
+			return;
+		}
+
+		infoVisible = false;
+		userPaused = true;
+		pauseCurrentDisplayClock();
+		await assetComponent?.pause?.();
+		await progressBar.pause();
+		await syncFrameSession();
+	}
+
+	async function togglePlayback() {
+		if (progressBarStatus == ProgressBarStatus.Paused) {
+			await resumePlayback();
+		} else {
+			await pausePlayback();
+		}
+	}
+
+	async function toggleInfo() {
+		if (adminStopped) {
+			return;
+		}
+
+		if (infoVisible) {
+			await resumePlayback();
+		} else {
+			infoVisible = true;
+			userPaused = true;
+			pauseCurrentDisplayClock();
+			await assetComponent?.pause?.();
+			await progressBar.pause();
+			await syncFrameSession();
+		}
+	}
+
+	async function shutdownFromAdmin() {
+		if (adminStopped) {
+			return;
+		}
+
+		adminStopped = true;
+		infoVisible = false;
+		userPaused = true;
+		stopSessionLoops();
+		progressBar.restart(false);
+		await assetComponent?.pause?.();
+		await progressBar.pause();
+		await syncFrameSession('Stopped');
+	}
+
+	async function processPendingCommands() {
+		if (adminStopped || isPollingCommands || isHandlingRemoteCommand || !$clientIdentifierStore) {
+			return;
+		}
+
+		isPollingCommands = true;
+		try {
+			const commands = await getFrameSessionCommands($clientIdentifierStore);
+			for (const command of commands) {
+				isHandlingRemoteCommand = true;
+				try {
+					switch (command.commandType) {
+						case 'Previous':
+							await handleDone(true, true);
+							infoVisible = false;
+							break;
+						case 'Play':
+							if (progressBarStatus === ProgressBarStatus.Paused || infoVisible || userPaused) {
+								await resumePlayback();
+							}
+							break;
+						case 'Pause':
+							if (progressBarStatus !== ProgressBarStatus.Paused) {
+								await pausePlayback();
+							}
+							break;
+						case 'Next':
+							await handleDone(false, true);
+							infoVisible = false;
+							break;
+						case 'Refresh':
+							await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
+							window.location.reload();
+							return;
+						case 'Shutdown':
+							await shutdownFromAdmin();
+							break;
+					}
+
+					await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
+				} catch (err) {
+					console.warn('Failed to handle remote command:', err);
+				} finally {
+					isHandlingRemoteCommand = false;
+				}
+			}
+		} finally {
+			isPollingCommands = false;
+		}
+	}
+
 	onMount(() => {
 		window.addEventListener('mousemove', showCursor);
 		window.addEventListener('click', showCursor);
+		window.addEventListener('beforeunload', handleBeforeUnload);
+
 		if ($configStore.primaryColor) {
 			document.documentElement.style.setProperty('--primary-color', $configStore.primaryColor);
 		}
@@ -403,6 +679,7 @@
 			if (value) {
 				progressBar.restart(value);
 				assetComponent?.play?.();
+				void syncFrameSession();
 			}
 		});
 
@@ -410,18 +687,36 @@
 			if (value) {
 				progressBar.restart(false);
 				assetComponent?.pause?.();
+				void syncFrameSession();
 			}
 		});
 
-		getNextAssets();
+		startSessionLoops();
+		void syncFrameSession();
+		void getNextAssets().then(() => syncFrameSession());
 
 		return () => {
 			window.removeEventListener('mousemove', showCursor);
 			window.removeEventListener('click', showCursor);
+			window.removeEventListener('beforeunload', handleBeforeUnload);
 		};
 	});
 
+	async function handleBeforeUnload() {
+		if (!$clientIdentifierStore) {
+			return;
+		}
+
+		try {
+			await disconnectFrameSession($clientIdentifierStore, true);
+		} catch (err) {
+			console.warn('Failed to disconnect frame session during unload:', err);
+		}
+	}
+
 	onDestroy(async () => {
+		stopSessionLoops();
+
 		if (unsubscribeRestart) {
 			unsubscribeRestart();
 		}
@@ -444,7 +739,22 @@
 </script>
 
 <section class="fixed grid h-dvh-safe w-screen bg-black" class:cursor-none={!cursorVisible}>
-	{#if error}
+	{#if adminStopped}
+		<div class="place-self-center w-full max-w-2xl px-8">
+			<div
+				class="rounded-[2rem] border border-white/10 bg-white/10 p-10 text-center text-white shadow-2xl backdrop-blur"
+			>
+				<p class="text-xs uppercase tracking-[0.45em] text-white/60">Remote Control</p>
+				<h1 class="mt-4 text-4xl font-semibold">Frame Stopped</h1>
+				<p class="mt-4 text-lg text-white/70">
+					This frame session was stopped from the admin dashboard. Refresh the page to reconnect.
+				</p>
+				{#if $clientIdentifierStore}
+					<p class="mt-6 font-mono text-sm text-white/50">Session: {$clientIdentifierStore}</p>
+				{/if}
+			</div>
+		</div>
+	{:else if error}
 		<ErrorElement {authError} message={errorMessage} />
 	{:else if displayingAssets}
 		<div class="absolute h-screen w-screen">
@@ -464,11 +774,15 @@
 				bind:showInfo={infoVisible}
 				playAudio={$configStore.playAudio}
 				onVideoWaiting={async () => {
+					pauseCurrentDisplayClock();
 					await progressBar.pause();
+					await syncFrameSession();
 				}}
 				onVideoPlaying={async () => {
 					if (!userPaused) {
+						resumeCurrentDisplayClock();
 						await progressBar.play();
+						await syncFrameSession();
 					}
 				}}
 			/>
@@ -489,31 +803,8 @@
 				await handleDone(true, true);
 				infoVisible = false;
 			}}
-			pause={async () => {
-				infoVisible = false;
-				if (progressBarStatus == ProgressBarStatus.Paused) {
-					userPaused = false;
-					await assetComponent?.play?.();
-					await progressBar.play();
-				} else {
-					userPaused = true;
-					await assetComponent?.pause?.();
-					await progressBar.pause();
-				}
-			}}
-			showInfo={async () => {
-				if (infoVisible) {
-					infoVisible = false;
-					userPaused = false;
-					await assetComponent?.play?.();
-					await progressBar.play();
-				} else {
-					infoVisible = true;
-					userPaused = true;
-					await assetComponent?.pause?.();
-					await progressBar.pause();
-				}
-			}}
+			pause={togglePlayback}
+			showInfo={toggleInfo}
 			bind:status={progressBarStatus}
 			bind:infoVisible
 			overlayVisible={cursorVisible}

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -23,7 +23,8 @@
 		acknowledgeFrameSessionCommand,
 		disconnectFrameSession,
 		getFrameSessionCommands,
-		putFrameSessionSnapshot
+		putFrameSessionSnapshot,
+		sendBeaconFrameSessionDisconnect
 	} from '$lib/frameSessionApi';
 
 	interface AssetsState {
@@ -707,8 +708,12 @@
 			return;
 		}
 
+		if (sendBeaconFrameSessionDisconnect($clientIdentifierStore, $authSecretStore)) {
+			return;
+		}
+
 		try {
-			await disconnectFrameSession($clientIdentifierStore, true);
+			await disconnectFrameSession($clientIdentifierStore, true, $authSecretStore);
 		} catch (err) {
 			console.warn('Failed to disconnect frame session during unload:', err);
 		}

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -91,10 +91,15 @@
 	let commandPollIntervalId: number | undefined;
 	let isPollingCommands = false;
 	let isHandlingRemoteCommand = false;
+	let isSyncInFlight = false;
+	let pendingSync = false;
+	let pendingSyncStatus: 'Active' | 'Stopped' | null = null;
 	let pendingDisplayNameSync = $state(false);
+	let overlayPausedPlayback = $state(false);
 	let lastAppliedClientIdentifierFromUrl: string | null | undefined = $state(undefined);
 	let lastAppliedClientNameFromUrl: string | null | undefined = $state(undefined);
 	let lastAppliedAuthSecretFromUrl: string | null | undefined = $state(undefined);
+	let handledCommandIds = new Set<number>();
 
 	$effect(() => {
 		const clientIdentifierFromUrl = page.url.searchParams.get('client');
@@ -131,7 +136,13 @@
 	setContext('close', provideClose);
 
 	async function provideClose() {
-		await resumePlayback();
+		if (overlayPausedPlayback) {
+			overlayPausedPlayback = false;
+			await resumePlayback();
+			return;
+		}
+
+		infoVisible = false;
 	}
 
 	const showCursor = () => {
@@ -224,7 +235,15 @@
 			return;
 		}
 
+		if (isSyncInFlight) {
+			pendingSync = true;
+			pendingSyncStatus =
+				status === 'Stopped' || pendingSyncStatus == null ? status : pendingSyncStatus;
+			return;
+		}
+
 		const shouldSyncDisplayName = pendingDisplayNameSync;
+		isSyncInFlight = true;
 		try {
 			await putFrameSessionSnapshot($clientIdentifierStore, {
 				playbackState:
@@ -239,6 +258,14 @@
 			}
 		} catch (err) {
 			console.warn('Failed to sync frame session:', err);
+		} finally {
+			isSyncInFlight = false;
+			if (pendingSync) {
+				const retryStatus = pendingSyncStatus ?? (adminStopped ? 'Stopped' : 'Active');
+				pendingSync = false;
+				pendingSyncStatus = null;
+				await syncFrameSession(retryStatus);
+			}
 		}
 	}
 
@@ -570,6 +597,7 @@
 			return;
 		}
 
+		overlayPausedPlayback = false;
 		infoVisible = false;
 		userPaused = false;
 		resumeCurrentDisplayClock();
@@ -605,14 +633,22 @@
 		}
 
 		if (infoVisible) {
-			await resumePlayback();
+			if (overlayPausedPlayback) {
+				overlayPausedPlayback = false;
+				await resumePlayback();
+			} else {
+				infoVisible = false;
+			}
 		} else {
 			infoVisible = true;
-			userPaused = true;
-			pauseCurrentDisplayClock();
-			await assetComponent?.pause?.();
-			await progressBar.pause();
-			await syncFrameSession();
+			overlayPausedPlayback = progressBarStatus !== ProgressBarStatus.Paused;
+			if (overlayPausedPlayback) {
+				userPaused = true;
+				pauseCurrentDisplayClock();
+				await assetComponent?.pause?.();
+				await progressBar.pause();
+				await syncFrameSession();
+			}
 		}
 	}
 
@@ -622,6 +658,7 @@
 		}
 
 		adminStopped = true;
+		overlayPausedPlayback = false;
 		infoVisible = false;
 		userPaused = true;
 		stopSessionLoops();
@@ -640,6 +677,11 @@
 		try {
 			const commands = await getFrameSessionCommands($clientIdentifierStore);
 			for (const command of commands) {
+				if (handledCommandIds.has(command.commandId)) {
+					continue;
+				}
+
+				handledCommandIds.add(command.commandId);
 				isHandlingRemoteCommand = true;
 				try {
 					switch (command.commandType) {
@@ -663,15 +705,18 @@
 							break;
 						case 'Refresh':
 							await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
+							handledCommandIds.delete(command.commandId);
 							window.location.reload();
 							return;
 						case 'Shutdown':
 							await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
+							handledCommandIds.delete(command.commandId);
 							await shutdownFromAdmin();
-							continue;
+							return;
 					}
 
 					await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
+					handledCommandIds.delete(command.commandId);
 				} catch (err) {
 					console.warn('Failed to handle remote command:', err);
 				} finally {

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -761,9 +761,11 @@
 			}
 		});
 
-		startSessionLoops();
-		void syncFrameSession();
-		void getNextAssets().then(() => syncFrameSession());
+		void (async () => {
+			await getNextAssets();
+			await syncFrameSession();
+			startSessionLoops();
+		})();
 
 		return () => {
 			window.removeEventListener('mousemove', showCursor);

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -91,23 +91,38 @@
 	let commandPollIntervalId: number | undefined;
 	let isPollingCommands = false;
 	let isHandlingRemoteCommand = false;
+	let pendingDisplayNameSync = $state(false);
+	let lastAppliedClientIdentifierFromUrl: string | null | undefined = $state(undefined);
+	let lastAppliedClientNameFromUrl: string | null | undefined = $state(undefined);
+	let lastAppliedAuthSecretFromUrl: string | null | undefined = $state(undefined);
 
-	const clientIdentifier = page.url.searchParams.get('client');
-	const clientName = page.url.searchParams.get('name');
-	const authsecret = page.url.searchParams.get('authsecret');
+	$effect(() => {
+		const clientIdentifierFromUrl = page.url.searchParams.get('client');
+		if (clientIdentifierFromUrl !== lastAppliedClientIdentifierFromUrl) {
+			lastAppliedClientIdentifierFromUrl = clientIdentifierFromUrl;
+			if (clientIdentifierFromUrl && clientIdentifierFromUrl !== $clientIdentifierStore) {
+				clientIdentifierStore.set(clientIdentifierFromUrl);
+			}
+		}
 
-	if (clientIdentifier && clientIdentifier != $clientIdentifierStore) {
-		clientIdentifierStore.set(clientIdentifier);
-	}
+		const clientNameFromUrl = page.url.searchParams.get('name');
+		if (clientNameFromUrl !== lastAppliedClientNameFromUrl) {
+			lastAppliedClientNameFromUrl = clientNameFromUrl;
+			if (clientNameFromUrl && clientNameFromUrl !== $clientNameStore) {
+				clientNameStore.set(clientNameFromUrl);
+				pendingDisplayNameSync = true;
+			}
+		}
 
-	if (clientName && clientName != $clientNameStore) {
-		clientNameStore.set(clientName);
-	}
-
-	if (authsecret && authsecret != $authSecretStore) {
-		authSecretStore.set(authsecret);
-		api.init();
-	}
+		const authSecretFromUrl = page.url.searchParams.get('authsecret');
+		if (authSecretFromUrl !== lastAppliedAuthSecretFromUrl) {
+			lastAppliedAuthSecretFromUrl = authSecretFromUrl;
+			if (authSecretFromUrl && authSecretFromUrl !== $authSecretStore) {
+				authSecretStore.set(authSecretFromUrl);
+				api.init();
+			}
+		}
+	});
 
 	const hideCursor = () => {
 		cursorVisible = false;
@@ -209,15 +224,19 @@
 			return;
 		}
 
+		const shouldSyncDisplayName = pendingDisplayNameSync;
 		try {
 			await putFrameSessionSnapshot($clientIdentifierStore, {
 				playbackState:
 					adminStopped || progressBarStatus === ProgressBarStatus.Paused ? 'Paused' : 'Playing',
 				status,
-				displayName: $clientNameStore,
+				displayName: shouldSyncDisplayName ? ($clientNameStore ?? null) : undefined,
 				currentDisplay: buildCurrentDisplay(),
 				history: buildHistory()
 			});
+			if (shouldSyncDisplayName) {
+				pendingDisplayNameSync = false;
+			}
 		} catch (err) {
 			console.warn('Failed to sync frame session:', err);
 		}
@@ -357,6 +376,10 @@
 
 	async function getPreviousAssets() {
 		if (!assetHistory.length) {
+			if (displayingAssets.length) {
+				setCurrentDisplay(displayingAssets);
+				currentDisplayDurationSeconds = currentDuration;
+			}
 			return;
 		}
 
@@ -643,7 +666,9 @@
 							window.location.reload();
 							return;
 						case 'Shutdown':
+							await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
 							await shutdownFromAdmin();
+							continue;
 							break;
 					}
 

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -669,7 +669,6 @@
 							await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);
 							await shutdownFromAdmin();
 							continue;
-							break;
 					}
 
 					await acknowledgeFrameSessionCommand($clientIdentifierStore, command.commandId);

--- a/immichFrame.Web/src/lib/frameSessionApi.ts
+++ b/immichFrame.Web/src/lib/frameSessionApi.ts
@@ -93,11 +93,15 @@ export async function putFrameSessionSnapshot(
 	clientIdentifier: string,
 	snapshot: FrameSessionSnapshotDto
 ) {
-	return fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}`, {
+	const response = await fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}`, {
 		method: 'PUT',
 		headers: getHeaders(true),
 		body: JSON.stringify(snapshot)
 	});
+
+	throwIfNotOk(response, `Failed to sync frame session: ${response.status}`);
+
+	return response;
 }
 
 export async function getFrameSessionCommands(clientIdentifier: string) {
@@ -125,10 +129,17 @@ export async function getFrameSessionCommands(clientIdentifier: string) {
 }
 
 export async function acknowledgeFrameSessionCommand(clientIdentifier: string, commandId: number) {
-	return fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands/${commandId}/ack`, {
+	const response = await fetch(
+		`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands/${commandId}/ack`,
+		{
 		method: 'POST',
 		headers: getHeaders()
-	});
+		}
+	);
+
+	throwIfNotOk(response, `Failed to acknowledge frame session command: ${response.status}`);
+
+	return response;
 }
 
 export async function disconnectFrameSession(

--- a/immichFrame.Web/src/lib/frameSessionApi.ts
+++ b/immichFrame.Web/src/lib/frameSessionApi.ts
@@ -37,7 +37,6 @@ export interface FrameSessionSnapshotDto {
 
 export interface FrameSessionStateDto extends FrameSessionSnapshotDto {
 	clientIdentifier: string;
-	displayName?: string | null;
 	connectedAtUtc: string;
 	lastSeenAtUtc: string;
 	userAgent?: string | null;
@@ -102,14 +101,27 @@ export async function putFrameSessionSnapshot(
 }
 
 export async function getFrameSessionCommands(clientIdentifier: string) {
-	const response = await fetch(
-		`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands`,
-		{
-			headers: getHeaders()
-		}
-	);
+	try {
+		const response = await fetch(
+			`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands`,
+			{
+				headers: getHeaders()
+			}
+		);
 
-	return response.ok ? readJson<AdminCommandDto[]>(response) : [];
+		if (!response.ok) {
+			const responseText = await response.text();
+			console.error(
+				`Failed to fetch frame session commands for ${clientIdentifier}: ${response.status} ${responseText}`
+			);
+			return [];
+		}
+
+		return await readJson<AdminCommandDto[]>(response);
+	} catch (error) {
+		console.error(`Failed to fetch frame session commands for ${clientIdentifier}:`, error);
+		return [];
+	}
 }
 
 export async function acknowledgeFrameSessionCommand(clientIdentifier: string, commandId: number) {
@@ -119,12 +131,35 @@ export async function acknowledgeFrameSessionCommand(clientIdentifier: string, c
 	});
 }
 
-export async function disconnectFrameSession(clientIdentifier: string, keepalive = false) {
+export async function disconnectFrameSession(
+	clientIdentifier: string,
+	keepalive = false,
+	authSecret?: string | null
+) {
 	return fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/disconnect`, {
 		method: 'POST',
-		headers: getHeaders(),
+		headers: authSecret ? getHeaders(true) : getHeaders(),
+		body: authSecret ? JSON.stringify({ authSecret }) : undefined,
 		keepalive
 	});
+}
+
+export function sendBeaconFrameSessionDisconnect(
+	clientIdentifier: string,
+	authSecret?: string | null
+) {
+	if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') {
+		return false;
+	}
+
+	const payload = JSON.stringify({
+		authSecret: authSecret ?? null
+	});
+	const body = new Blob([payload], { type: 'application/json' });
+	return navigator.sendBeacon(
+		`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/disconnect`,
+		body
+	);
 }
 
 export async function getAdminFrameSessions() {

--- a/immichFrame.Web/src/lib/frameSessionApi.ts
+++ b/immichFrame.Web/src/lib/frameSessionApi.ts
@@ -1,0 +1,201 @@
+import { get } from 'svelte/store';
+import { authSecretStore } from '$lib/stores/persist.store';
+
+export type FramePlaybackState = 'Playing' | 'Paused';
+export type FrameSessionStatus = 'Active' | 'Stopped';
+export type FrameAdminCommandType =
+	| 'Previous'
+	| 'Play'
+	| 'Pause'
+	| 'Next'
+	| 'Refresh'
+	| 'Shutdown';
+
+export interface DisplayedAssetDto {
+	id: string;
+	originalFileName: string;
+	type: number;
+	immichServerUrl?: string | null;
+	localDateTime?: string | null;
+	description?: string | null;
+	thumbhash?: string | null;
+}
+
+export interface DisplayEventDto {
+	displayedAtUtc: string;
+	durationSeconds?: number | null;
+	assets: DisplayedAssetDto[];
+}
+
+export interface FrameSessionSnapshotDto {
+	playbackState: FramePlaybackState;
+	status: FrameSessionStatus;
+	displayName?: string | null;
+	currentDisplay?: DisplayEventDto | null;
+	history: DisplayEventDto[];
+}
+
+export interface FrameSessionStateDto extends FrameSessionSnapshotDto {
+	clientIdentifier: string;
+	displayName?: string | null;
+	connectedAtUtc: string;
+	lastSeenAtUtc: string;
+	userAgent?: string | null;
+}
+
+export interface AdminCommandDto {
+	commandId: number;
+	commandType: FrameAdminCommandType;
+	issuedAtUtc: string;
+}
+
+export interface AdminAuthSessionDto {
+	isConfigured: boolean;
+	isAuthenticated: boolean;
+	username?: string | null;
+}
+
+export class FrameSessionApiError extends Error {
+	status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = 'FrameSessionApiError';
+		this.status = status;
+	}
+}
+
+function getHeaders(includeJsonBody = false): HeadersInit {
+	const headers: Record<string, string> = {};
+	const authSecret = get(authSecretStore);
+
+	if (authSecret) {
+		headers.Authorization = `Bearer ${authSecret}`;
+	}
+
+	if (includeJsonBody) {
+		headers['Content-Type'] = 'application/json';
+	}
+
+	return headers;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+function throwIfNotOk(response: Response, message: string) {
+	if (!response.ok) {
+		throw new FrameSessionApiError(message, response.status);
+	}
+}
+
+export async function putFrameSessionSnapshot(
+	clientIdentifier: string,
+	snapshot: FrameSessionSnapshotDto
+) {
+	return fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}`, {
+		method: 'PUT',
+		headers: getHeaders(true),
+		body: JSON.stringify(snapshot)
+	});
+}
+
+export async function getFrameSessionCommands(clientIdentifier: string) {
+	const response = await fetch(
+		`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands`,
+		{
+			headers: getHeaders()
+		}
+	);
+
+	return response.ok ? readJson<AdminCommandDto[]>(response) : [];
+}
+
+export async function acknowledgeFrameSessionCommand(clientIdentifier: string, commandId: number) {
+	return fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands/${commandId}/ack`, {
+		method: 'POST',
+		headers: getHeaders()
+	});
+}
+
+export async function disconnectFrameSession(clientIdentifier: string, keepalive = false) {
+	return fetch(`/api/frame-sessions/${encodeURIComponent(clientIdentifier)}/disconnect`, {
+		method: 'POST',
+		headers: getHeaders(),
+		keepalive
+	});
+}
+
+export async function getAdminFrameSessions() {
+	const response = await fetch('/api/admin/frame-sessions', {
+		credentials: 'same-origin'
+	});
+
+	throwIfNotOk(response, `Failed to fetch frame sessions: ${response.status}`);
+
+	return readJson<FrameSessionStateDto[]>(response);
+}
+
+export async function enqueueAdminCommand(
+	clientIdentifier: string,
+	commandType: FrameAdminCommandType
+) {
+	const response = await fetch(`/api/admin/frame-sessions/${encodeURIComponent(clientIdentifier)}/commands`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		credentials: 'same-origin',
+		body: JSON.stringify({ commandType })
+	});
+
+	throwIfNotOk(response, `Failed to enqueue command: ${response.status}`);
+
+	return readJson<AdminCommandDto>(response);
+}
+
+export async function updateAdminFrameSessionDisplayName(
+	clientIdentifier: string,
+	displayName: string | null
+) {
+	const response = await fetch(
+		`/api/admin/frame-sessions/${encodeURIComponent(clientIdentifier)}/display-name`,
+		{
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'same-origin',
+			body: JSON.stringify({ displayName })
+		}
+	);
+
+	throwIfNotOk(response, `Failed to update session name: ${response.status}`);
+}
+
+export async function getAdminAuthSession() {
+	const response = await fetch('/api/admin/auth/session', {
+		credentials: 'same-origin'
+	});
+
+	throwIfNotOk(response, `Failed to fetch admin session: ${response.status}`);
+	return readJson<AdminAuthSessionDto>(response);
+}
+
+export async function loginAdmin(username: string, password: string) {
+	const response = await fetch('/api/admin/auth/login', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		credentials: 'same-origin',
+		body: JSON.stringify({ username, password })
+	});
+
+	throwIfNotOk(response, `Failed to log in: ${response.status}`);
+	return readJson<AdminAuthSessionDto>(response);
+}
+
+export async function logoutAdmin() {
+	const response = await fetch('/api/admin/auth/logout', {
+		method: 'POST',
+		credentials: 'same-origin'
+	});
+
+	throwIfNotOk(response, `Failed to log out: ${response.status}`);
+}

--- a/immichFrame.Web/src/lib/stores/persist.store.ts
+++ b/immichFrame.Web/src/lib/stores/persist.store.ts
@@ -23,4 +23,5 @@ function generateGUID() {
 }
 
 export const clientIdentifierStore = persistStore('clientIdentifier', generateGUID());
+export const clientNameStore = persistStore('clientName', null);
 export const authSecretStore = persistStore('authSecret', null);

--- a/immichFrame.Web/src/routes/+page.ts
+++ b/immichFrame.Web/src/routes/+page.ts
@@ -1,9 +1,9 @@
 import * as api from '$lib/immichFrameApi';
 import { configStore } from '$lib/stores/config.store.js'
 
-export const load = async () => {
+export const load = async ({ fetch }) => {
 
-  const configRequest = await api.getConfig({ clientIdentifier: "" });
+  const configRequest = await api.getConfig({ clientIdentifier: "" }, { fetch });
 
   const config = configRequest.data;
 

--- a/immichFrame.Web/src/routes/admin/+page.svelte
+++ b/immichFrame.Web/src/routes/admin/+page.svelte
@@ -1,0 +1,895 @@
+<script lang="ts">
+	import { mdiCheck, mdiLogout, mdiPencilOutline } from '@mdi/js';
+	import { onDestroy, onMount } from 'svelte';
+	import ErrorElement from '$lib/components/elements/error-element.svelte';
+	import Icon from '$lib/components/elements/icon.svelte';
+	import {
+		enqueueAdminCommand,
+		FrameSessionApiError,
+		getAdminAuthSession,
+		getAdminFrameSessions,
+		loginAdmin,
+		logoutAdmin,
+		updateAdminFrameSessionDisplayName
+	} from '$lib/frameSessionApi';
+	import type {
+		AdminAuthSessionDto,
+		DisplayedAssetDto,
+		FrameAdminCommandType,
+		FrameSessionStateDto
+	} from '$lib/frameSessionApi';
+
+	const REFRESH_INTERVAL_MS = 5_000;
+	const PROGRESS_REFRESH_INTERVAL_MS = 250;
+
+	interface FrozenProgressSnapshot {
+		displayedAtUtc: string;
+		durationSeconds: number;
+		progress: number;
+	}
+
+	let adminSession: AdminAuthSessionDto | null = $state(null);
+	let sessions: FrameSessionStateDto[] = $state([]);
+	let sessionOrder: string[] = $state([]);
+	let authLoading = $state(true);
+	let loading = $state(false);
+	let hasLoadedSessionsOnce = $state(false);
+	let fatalErrorMessage = $state('');
+	let errorMessage = $state('');
+	let authErrorMessage = $state('');
+	let loginUsername = $state('');
+	let loginPassword = $state('');
+	let loginPending = $state(false);
+	let nowMs = $state(Date.now());
+	let actionState: Record<string, FrameAdminCommandType | null> = $state({});
+	let displayNameDrafts: Record<string, string> = $state({});
+	let savingDisplayName: Record<string, boolean> = $state({});
+	let frozenProgressBySession: Record<string, FrozenProgressSnapshot> = $state({});
+	let editingSessionId: string | null = $state(null);
+	let refreshIntervalId: number | undefined;
+	let progressIntervalId: number | undefined;
+
+	function formatDateTime(value?: string | null) {
+		if (!value) {
+			return 'Unknown';
+		}
+
+		return new Intl.DateTimeFormat(undefined, {
+			dateStyle: 'medium',
+			timeStyle: 'short'
+		}).format(new Date(value));
+	}
+
+	function formatAssetType(type: number) {
+		switch (type) {
+			case 0:
+				return 'Image';
+			case 1:
+				return 'Video';
+			case 2:
+				return 'Audio';
+			default:
+				return 'Other';
+		}
+	}
+
+	function getCurrentAssets(session: FrameSessionStateDto) {
+		return session.currentDisplay?.assets ?? [];
+	}
+
+	function getHistory(session: FrameSessionStateDto) {
+		return session.history ?? [];
+	}
+
+	function getDisplayName(session: FrameSessionStateDto) {
+		return session.displayName?.trim() || `Frame ${session.clientIdentifier.slice(0, 8)}`;
+	}
+
+	function parseUserAgent(userAgent?: string | null) {
+		if (!userAgent) {
+			return {
+				summary: 'Unknown device',
+				details: ''
+			};
+		}
+
+		const ua = userAgent;
+		const os = ua.includes('Windows')
+			? 'Windows'
+			: ua.includes('Mac OS X')
+				? 'macOS'
+				: ua.includes('Android')
+					? 'Android'
+					: ua.includes('iPhone') || ua.includes('iPad')
+						? 'iOS'
+						: ua.includes('Linux')
+							? 'Linux'
+							: 'Unknown OS';
+
+		const browser = ua.includes('Edg/')
+			? 'Microsoft Edge'
+			: ua.includes('Chrome/')
+				? 'Chrome'
+				: ua.includes('Firefox/')
+					? 'Firefox'
+					: ua.includes('Safari/') && !ua.includes('Chrome/')
+						? 'Safari'
+						: 'Browser';
+
+		return {
+			summary: `${browser} on ${os}`,
+			details: userAgent
+		};
+	}
+
+	function getDurationSeconds(session: FrameSessionStateDto) {
+		return session.currentDisplay?.durationSeconds ?? null;
+	}
+
+	function clampProgress(progress: number) {
+		return Math.max(0, Math.min(1, progress));
+	}
+
+	function computeRawProgress(session: FrameSessionStateDto, referenceMs: number) {
+		const currentDisplay = session.currentDisplay;
+		const durationSeconds = getDurationSeconds(session);
+		if (!currentDisplay?.displayedAtUtc || !durationSeconds || durationSeconds <= 0) {
+			return 0;
+		}
+
+		const startedAtMs = new Date(currentDisplay.displayedAtUtc).getTime();
+		const durationMs = durationSeconds * 1000;
+		return clampProgress((referenceMs - startedAtMs) / durationMs);
+	}
+
+	function syncDrafts(data: FrameSessionStateDto[]) {
+		const nextDrafts: Record<string, string> = {};
+		for (const session of data) {
+			nextDrafts[session.clientIdentifier] =
+				displayNameDrafts[session.clientIdentifier] ?? session.displayName ?? '';
+		}
+		displayNameDrafts = nextDrafts;
+	}
+
+	function syncFrozenProgress(data: FrameSessionStateDto[]) {
+		const nextFrozenProgress: Record<string, FrozenProgressSnapshot> = {};
+
+		for (const session of data) {
+			const currentDisplay = session.currentDisplay;
+			const durationSeconds = getDurationSeconds(session);
+
+			if (!currentDisplay?.displayedAtUtc || !durationSeconds || durationSeconds <= 0) {
+				continue;
+			}
+
+			if (session.playbackState !== 'Paused') {
+				continue;
+			}
+
+			const existing = frozenProgressBySession[session.clientIdentifier];
+			if (
+				existing &&
+				existing.displayedAtUtc === currentDisplay.displayedAtUtc &&
+				existing.durationSeconds === durationSeconds
+			) {
+				nextFrozenProgress[session.clientIdentifier] = existing;
+				continue;
+			}
+
+			nextFrozenProgress[session.clientIdentifier] = {
+				displayedAtUtc: currentDisplay.displayedAtUtc,
+				durationSeconds,
+				progress: computeRawProgress(session, Date.now())
+			};
+		}
+
+		frozenProgressBySession = nextFrozenProgress;
+	}
+
+	function orderSessions(data: FrameSessionStateDto[]) {
+		const presentSessionIds = new Set(data.map((session) => session.clientIdentifier));
+		const nextOrder = sessionOrder.filter((sessionId) => presentSessionIds.has(sessionId));
+
+		for (const session of data) {
+			if (!nextOrder.includes(session.clientIdentifier)) {
+				nextOrder.push(session.clientIdentifier);
+			}
+		}
+
+		sessionOrder = nextOrder;
+		const orderIndex = new Map(nextOrder.map((sessionId, index) => [sessionId, index]));
+
+		return [...data].sort(
+			(a, b) =>
+				(orderIndex.get(a.clientIdentifier) ?? Number.MAX_SAFE_INTEGER) -
+				(orderIndex.get(b.clientIdentifier) ?? Number.MAX_SAFE_INTEGER)
+		);
+	}
+
+	function getProgress(session: FrameSessionStateDto) {
+		const currentDisplay = session.currentDisplay;
+		const durationSeconds = getDurationSeconds(session);
+		if (!currentDisplay?.displayedAtUtc || !durationSeconds || durationSeconds <= 0) {
+			return 0;
+		}
+
+		const frozen = frozenProgressBySession[session.clientIdentifier];
+		if (
+			session.playbackState === 'Paused' &&
+			frozen &&
+			frozen.displayedAtUtc === currentDisplay.displayedAtUtc &&
+			frozen.durationSeconds === durationSeconds
+		) {
+			return frozen.progress;
+		}
+
+		return computeRawProgress(session, nowMs);
+	}
+
+	function getProgressWidth(session: FrameSessionStateDto) {
+		return `${Math.round(getProgress(session) * 100)}%`;
+	}
+
+	function getCurrentMediaCardStyle(session: FrameSessionStateDto) {
+		const progressWidth = getProgressWidth(session);
+		const fillColor = 'color-mix(in srgb, var(--primary-color) 30%, transparent)';
+		const baseColor = 'rgba(0, 0, 0, 0.28)';
+
+		return `background-image: linear-gradient(90deg, ${fillColor} 0%, ${fillColor} ${progressWidth}, ${baseColor} ${progressWidth}, ${baseColor} 100%);`;
+	}
+
+	function getDisplayNameInputWidth(clientIdentifier: string) {
+		const draftLength = displayNameDrafts[clientIdentifier]?.length ?? 0;
+		return `${Math.min(Math.max(draftLength + 2, 16), 28)}ch`;
+	}
+
+	function getAssetUrl(asset: DisplayedAssetDto) {
+		const baseUrl = asset.immichServerUrl?.trim();
+		if (!baseUrl) {
+			return null;
+		}
+
+		return `${baseUrl.replace(/\/+$/, '')}/photos/${encodeURIComponent(asset.id)}`;
+	}
+
+	function isUnauthorizedError(error: unknown) {
+		return error instanceof FrameSessionApiError && error.status === 401;
+	}
+
+	function clearDashboardState() {
+		sessions = [];
+		sessionOrder = [];
+		actionState = {};
+		displayNameDrafts = {};
+		savingDisplayName = {};
+		frozenProgressBySession = {};
+		editingSessionId = null;
+		loading = false;
+		hasLoadedSessionsOnce = false;
+		errorMessage = '';
+	}
+
+	function applyLoggedOutState(message = '') {
+		adminSession = {
+			isConfigured: adminSession?.isConfigured ?? true,
+			isAuthenticated: false,
+			username: null
+		};
+		authErrorMessage = message;
+		loginPassword = '';
+		stopRefreshing();
+		clearDashboardState();
+	}
+
+	async function refreshAdminSession() {
+		const session = await getAdminAuthSession();
+		adminSession = session;
+		return session;
+	}
+
+	async function loadSessions(showSpinner = false) {
+		if (showSpinner && !hasLoadedSessionsOnce) {
+			loading = true;
+		}
+
+		try {
+			const data = await getAdminFrameSessions();
+			sessions = orderSessions(data);
+			syncDrafts(sessions);
+			syncFrozenProgress(sessions);
+			hasLoadedSessionsOnce = true;
+			errorMessage = '';
+		} catch (err) {
+			if (isUnauthorizedError(err)) {
+				applyLoggedOutState('Your admin session expired. Sign in again to keep managing frames.');
+				return;
+			}
+
+			console.warn('Failed to load frame sessions:', err);
+			errorMessage = 'The admin dashboard could not load its session data right now.';
+		} finally {
+			if (showSpinner) {
+				loading = false;
+			}
+		}
+	}
+
+	async function initializeAdminPage() {
+		authLoading = true;
+		fatalErrorMessage = '';
+
+		try {
+			const session = await refreshAdminSession();
+			authErrorMessage = '';
+
+			if (!session.isAuthenticated) {
+				stopRefreshing();
+				clearDashboardState();
+				return;
+			}
+
+			await loadSessions(true);
+			startRefreshing();
+		} catch (err) {
+			console.warn('Failed to initialize admin dashboard:', err);
+			fatalErrorMessage =
+				'The admin login page could not reach the server. Check that the backend is running and refresh.';
+			stopRefreshing();
+			clearDashboardState();
+		} finally {
+			authLoading = false;
+		}
+	}
+
+	async function submitLogin() {
+		loginPending = true;
+		authErrorMessage = '';
+
+		try {
+			adminSession = await loginAdmin(loginUsername.trim(), loginPassword);
+			loginPassword = '';
+			await loadSessions(true);
+			startRefreshing();
+		} catch (err) {
+			if (err instanceof FrameSessionApiError) {
+				if (err.status === 401) {
+					authErrorMessage = 'That username or password was not accepted.';
+				} else if (err.status === 503) {
+					authErrorMessage =
+						'Admin login is not configured. Add IMMICHFRAME_AUTH_BASIC_* credentials to your environment and restart the app.';
+				} else {
+					authErrorMessage = 'The admin login request failed. Try again in a moment.';
+				}
+			} else {
+				authErrorMessage = 'The admin login request failed. Try again in a moment.';
+			}
+		} finally {
+			loginPending = false;
+		}
+	}
+
+	async function handleLogout() {
+		try {
+			await logoutAdmin();
+		} catch (err) {
+			if (!isUnauthorizedError(err)) {
+				console.warn('Failed to log out admin session:', err);
+			}
+		}
+
+		applyLoggedOutState('');
+	}
+
+	async function sendCommand(clientIdentifier: string, commandType: FrameAdminCommandType) {
+		actionState = {
+			...actionState,
+			[clientIdentifier]: commandType
+		};
+
+		try {
+			await enqueueAdminCommand(clientIdentifier, commandType);
+			await loadSessions();
+		} catch (err) {
+			if (isUnauthorizedError(err)) {
+				applyLoggedOutState('Your admin session expired. Sign in again to keep managing frames.');
+				return;
+			}
+
+			console.warn('Failed to enqueue admin command:', err);
+		} finally {
+			actionState = {
+				...actionState,
+				[clientIdentifier]: null
+			};
+		}
+	}
+
+	function beginEditingName(session: FrameSessionStateDto) {
+		displayNameDrafts = {
+			...displayNameDrafts,
+			[session.clientIdentifier]: session.displayName ?? ''
+		};
+		editingSessionId = session.clientIdentifier;
+	}
+
+	function cancelEditingName(session: FrameSessionStateDto) {
+		displayNameDrafts = {
+			...displayNameDrafts,
+			[session.clientIdentifier]: session.displayName ?? ''
+		};
+		if (editingSessionId === session.clientIdentifier) {
+			editingSessionId = null;
+		}
+	}
+
+	async function saveDisplayName(clientIdentifier: string) {
+		savingDisplayName = {
+			...savingDisplayName,
+			[clientIdentifier]: true
+		};
+
+		try {
+			const nextName = displayNameDrafts[clientIdentifier]?.trim() || null;
+			await updateAdminFrameSessionDisplayName(clientIdentifier, nextName);
+			editingSessionId = null;
+			await loadSessions();
+		} catch (err) {
+			if (isUnauthorizedError(err)) {
+				applyLoggedOutState('Your admin session expired. Sign in again to keep managing frames.');
+				return;
+			}
+
+			console.warn('Failed to update session name:', err);
+		} finally {
+			savingDisplayName = {
+				...savingDisplayName,
+				[clientIdentifier]: false
+			};
+		}
+	}
+
+	function handleEditBlur(session: FrameSessionStateDto, event: FocusEvent) {
+		const relatedTarget = event.relatedTarget as HTMLElement | null;
+		if (relatedTarget?.dataset.saveNameFor === session.clientIdentifier) {
+			return;
+		}
+
+		cancelEditingName(session);
+	}
+
+	function getActionLabel(session: FrameSessionStateDto) {
+		return session.playbackState === 'Paused' ? 'Play' : 'Pause';
+	}
+
+	function getActionCommand(session: FrameSessionStateDto): FrameAdminCommandType {
+		return session.playbackState === 'Paused' ? 'Play' : 'Pause';
+	}
+
+	function startRefreshing() {
+		stopRefreshing();
+
+		refreshIntervalId = window.setInterval(() => {
+			void loadSessions();
+		}, REFRESH_INTERVAL_MS);
+
+		progressIntervalId = window.setInterval(() => {
+			nowMs = Date.now();
+		}, PROGRESS_REFRESH_INTERVAL_MS);
+	}
+
+	function stopRefreshing() {
+		if (refreshIntervalId) {
+			clearInterval(refreshIntervalId);
+			refreshIntervalId = undefined;
+		}
+
+		if (progressIntervalId) {
+			clearInterval(progressIntervalId);
+			progressIntervalId = undefined;
+		}
+	}
+
+	onMount(() => {
+		void initializeAdminPage();
+	});
+
+	onDestroy(() => {
+		stopRefreshing();
+	});
+</script>
+
+<svelte:head>
+	<title>immichFrame Admin</title>
+</svelte:head>
+
+{#if fatalErrorMessage}
+	<section class="min-h-dvh bg-[#10100e]">
+		<ErrorElement message={fatalErrorMessage} />
+	</section>
+{:else if authLoading}
+	<section class="min-h-dvh bg-[radial-gradient(circle_at_top,_rgba(245,222,179,0.16),_transparent_34%),linear-gradient(180deg,#14130f_0%,#0f100d_48%,#0b0c09_100%)] px-4 py-6 text-stone-100 sm:px-6 lg:px-10">
+		<div class="mx-auto max-w-xl rounded-[2rem] border border-white/10 bg-white/5 px-6 py-12 text-center shadow-2xl backdrop-blur">
+			Checking admin session...
+		</div>
+	</section>
+{:else if !adminSession?.isConfigured}
+	<section class="min-h-dvh bg-[radial-gradient(circle_at_top,_rgba(245,222,179,0.16),_transparent_34%),linear-gradient(180deg,#14130f_0%,#0f100d_48%,#0b0c09_100%)] px-4 py-6 text-stone-100 sm:px-6 lg:px-10">
+		<div class="mx-auto flex max-w-xl flex-col gap-5 rounded-[2rem] border border-white/10 bg-white/5 px-6 py-8 shadow-2xl backdrop-blur">
+			<p class="text-xs uppercase tracking-[0.45em] text-[color:var(--primary-color)]">
+				Admin Login
+			</p>
+			<h1 class="text-3xl font-semibold tracking-tight">Admin access is not configured.</h1>
+			<p class="text-sm text-stone-300">
+				Add at least one `IMMICHFRAME_AUTH_BASIC_*_USER` and matching
+				`IMMICHFRAME_AUTH_BASIC_*_HASH` value to your environment file, then restart the app.
+			</p>
+			<div class="rounded-2xl border border-white/10 bg-black/25 px-4 py-4 text-sm text-stone-300">
+				The admin login page uses the same `.env` htpasswd credentials you already configured for
+				admin access. No separate in-app account store is used.
+			</div>
+		</div>
+	</section>
+{:else if !adminSession.isAuthenticated}
+	<section class="min-h-dvh bg-[radial-gradient(circle_at_top,_rgba(245,222,179,0.16),_transparent_34%),linear-gradient(180deg,#14130f_0%,#0f100d_48%,#0b0c09_100%)] px-4 py-6 text-stone-100 sm:px-6 lg:px-10">
+		<div class="mx-auto flex max-w-xl flex-col gap-6 rounded-[2rem] border border-white/10 bg-white/5 px-6 py-8 shadow-2xl backdrop-blur">
+			<div>
+				<p class="text-xs uppercase tracking-[0.45em] text-[color:var(--primary-color)]">
+					Admin Login
+				</p>
+				<h1 class="mt-3 text-3xl font-semibold tracking-tight">Sign in to ImmichFrame Admin</h1>
+				<p class="mt-3 text-sm text-stone-300">
+					Use one of the admin usernames defined in your environment file.
+				</p>
+			</div>
+
+			<form
+				class="flex flex-col gap-4"
+				onsubmit={(event) => {
+					event.preventDefault();
+					void submitLogin();
+				}}
+			>
+				<label class="flex flex-col gap-2">
+					<span class="text-sm font-medium text-stone-200">Username</span>
+					<input
+						class="rounded-2xl border border-white/12 bg-stone-950/85 px-4 py-3 text-stone-100 outline-none transition placeholder:text-stone-500 focus:border-[color:var(--primary-color)]/75"
+						type="text"
+						autocomplete="username"
+						bind:value={loginUsername}
+						placeholder="admin"
+					/>
+				</label>
+
+				<label class="flex flex-col gap-2">
+					<span class="text-sm font-medium text-stone-200">Password</span>
+					<input
+						class="rounded-2xl border border-white/12 bg-stone-950/85 px-4 py-3 text-stone-100 outline-none transition placeholder:text-stone-500 focus:border-[color:var(--primary-color)]/75"
+						type="password"
+						autocomplete="current-password"
+						bind:value={loginPassword}
+						placeholder="Password"
+					/>
+				</label>
+
+				{#if authErrorMessage}
+					<div class="rounded-2xl border border-rose-400/25 bg-rose-400/10 px-4 py-3 text-sm text-rose-100">
+						{authErrorMessage}
+					</div>
+				{/if}
+
+				<button
+					class="rounded-full border border-[color:var(--primary-color)]/40 bg-[color:var(--primary-color)]/15 px-5 py-3 text-sm font-medium text-[color:var(--primary-color)] transition hover:bg-[color:var(--primary-color)]/25 disabled:cursor-wait disabled:opacity-50"
+					type="submit"
+					disabled={loginPending || loginUsername.trim().length === 0 || loginPassword.length === 0}
+				>
+					{loginPending ? 'Signing In...' : 'Sign In'}
+				</button>
+			</form>
+		</div>
+	</section>
+{:else}
+	<section class="min-h-dvh bg-[radial-gradient(circle_at_top,_rgba(245,222,179,0.16),_transparent_34%),linear-gradient(180deg,#14130f_0%,#0f100d_48%,#0b0c09_100%)] text-stone-100">
+		<div class="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-10">
+			<header class="rounded-[2rem] border border-white/10 bg-white/5 px-5 py-6 shadow-2xl backdrop-blur sm:px-6">
+				<div class="flex flex-col gap-5">
+					<div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+						<div class="min-w-0">
+							<p class="text-xs uppercase tracking-[0.45em] text-[color:var(--primary-color)]">
+								Live Control
+							</p>
+							<h1 class="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+								ImmichFrame Sessions
+							</h1>
+							<p class="mt-3 max-w-2xl text-sm text-stone-300">
+								Monitor and control active ImmichFrame sessions. Inspect currently displayed media
+								or review any recently displayed media.
+							</p>
+						</div>
+
+						<div class="flex flex-wrap items-center gap-3">
+							<span class="rounded-full border border-white/12 bg-black/25 px-4 py-2 text-sm text-stone-300">
+								Signed in as {adminSession.username}
+							</span>
+							<button
+								class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm text-stone-100 transition hover:bg-white/10"
+								onclick={() => void handleLogout()}
+							>
+								<Icon path={mdiLogout} title="Log out" size="1rem" />
+								Log Out
+							</button>
+						</div>
+					</div>
+				</div>
+			</header>
+
+			{#if errorMessage}
+				<div class="rounded-[2rem] border border-amber-300/20 bg-amber-400/10 px-5 py-4 text-sm text-amber-100">
+					{errorMessage}
+				</div>
+			{/if}
+
+			{#if loading}
+				<div class="rounded-[2rem] border border-white/10 bg-white/5 px-6 py-12 text-center text-stone-300">
+					Loading active sessions...
+				</div>
+			{:else if sessions.length === 0}
+				<div class="rounded-[2rem] border border-dashed border-white/15 bg-black/20 px-6 py-14 text-center">
+					<p class="text-xs uppercase tracking-[0.4em] text-stone-400">No Active Sessions</p>
+					<h2 class="mt-4 text-3xl font-semibold">No frames are currently connected.</h2>
+					<p class="mt-3 text-sm text-stone-400">
+						Open the frame UI on a client device and it will appear here once it starts heartbeating.
+					</p>
+				</div>
+			{:else}
+				<div class="grid gap-6 xl:grid-cols-2">
+					{#each sessions as session (session.clientIdentifier)}
+						<div class="overflow-hidden rounded-[2rem] border border-white/10 bg-black/30 shadow-2xl backdrop-blur">
+							<div class="border-b border-white/10 px-5 py-5 sm:px-6">
+								<div class="flex flex-col gap-4">
+									<div class="flex min-w-0 flex-wrap items-center gap-3">
+										{#if editingSessionId === session.clientIdentifier}
+											<div class="inline-flex min-w-0 max-w-full items-center gap-2">
+												<input
+													class="min-w-0 rounded-full border border-[color:var(--primary-color)]/45 bg-stone-950/90 px-4 py-2 text-lg font-semibold text-stone-100 outline-none transition placeholder:text-stone-400 focus:border-[color:var(--primary-color)]/75 focus:bg-stone-950"
+													style:width={getDisplayNameInputWidth(session.clientIdentifier)}
+													value={displayNameDrafts[session.clientIdentifier] ?? ''}
+													placeholder="Name this frame"
+													oninput={(event) => {
+														const target = event.currentTarget as HTMLInputElement;
+														displayNameDrafts = {
+															...displayNameDrafts,
+															[session.clientIdentifier]: target.value
+														};
+													}}
+													onkeydown={(event) => {
+														if (event.key === 'Enter') {
+															event.preventDefault();
+															void saveDisplayName(session.clientIdentifier);
+														}
+														if (event.key === 'Escape') {
+															event.preventDefault();
+															cancelEditingName(session);
+														}
+													}}
+													onblur={(event) => handleEditBlur(session, event)}
+												/>
+												<button
+													class="shrink-0 rounded-full border border-[color:var(--primary-color)]/40 bg-[color:var(--primary-color)]/15 p-2 text-[color:var(--primary-color)] transition hover:bg-[color:var(--primary-color)]/25 disabled:opacity-50"
+													data-save-name-for={session.clientIdentifier}
+													disabled={savingDisplayName[session.clientIdentifier] === true}
+													onclick={() => saveDisplayName(session.clientIdentifier)}
+												>
+													<Icon path={mdiCheck} title="Save frame name" size="1.1rem" />
+												</button>
+											</div>
+										{:else}
+											<div class="inline-flex min-w-0 max-w-full items-center gap-2">
+												<h2 class="min-w-0 truncate text-2xl font-semibold">
+													{getDisplayName(session)}
+												</h2>
+												<button
+													class="shrink-0 rounded-full border border-white/15 bg-white/5 p-2 text-stone-200 transition hover:bg-white/10"
+													onclick={() => beginEditingName(session)}
+												>
+													<Icon path={mdiPencilOutline} title="Edit frame name" size="1rem" />
+												</button>
+											</div>
+										{/if}
+
+										<span
+											class="rounded-full border border-emerald-400/30 bg-emerald-400/15 px-3 py-1 text-xs uppercase tracking-[0.25em] text-emerald-300"
+										>
+											{session.playbackState}
+										</span>
+									</div>
+
+									<div class="min-w-0 space-y-2">
+										<p class="text-sm text-stone-300">{parseUserAgent(session.userAgent).summary}</p>
+										<p class="break-all font-mono text-xs text-stone-500">
+											ID: {session.clientIdentifier}
+										</p>
+										<p class="text-sm text-stone-400">
+											Connected {formatDateTime(session.connectedAtUtc)}
+										</p>
+										{#if session.userAgent}
+											<p class="break-words text-xs text-stone-500">
+												{parseUserAgent(session.userAgent).details}
+											</p>
+										{/if}
+									</div>
+
+									<div class="flex flex-wrap gap-2">
+										<button
+											class="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm transition hover:bg-white/10 disabled:cursor-wait disabled:opacity-50"
+											disabled={actionState[session.clientIdentifier] != null}
+											onclick={() => sendCommand(session.clientIdentifier, 'Previous')}
+										>
+											Previous
+										</button>
+										<button
+											class="rounded-full border border-[color:var(--primary-color)]/40 bg-[color:var(--primary-color)]/15 px-4 py-2 text-sm text-[color:var(--primary-color)] transition hover:bg-[color:var(--primary-color)]/25 disabled:cursor-wait disabled:opacity-50"
+											disabled={actionState[session.clientIdentifier] != null}
+											onclick={() => sendCommand(session.clientIdentifier, getActionCommand(session))}
+										>
+											{getActionLabel(session)}
+										</button>
+										<button
+											class="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm transition hover:bg-white/10 disabled:cursor-wait disabled:opacity-50"
+											disabled={actionState[session.clientIdentifier] != null}
+											onclick={() => sendCommand(session.clientIdentifier, 'Next')}
+										>
+											Next
+										</button>
+										<button
+											class="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm transition hover:bg-white/10 disabled:cursor-wait disabled:opacity-50"
+											disabled={actionState[session.clientIdentifier] != null}
+											onclick={() => sendCommand(session.clientIdentifier, 'Refresh')}
+										>
+											Refresh
+										</button>
+										<button
+											class="rounded-full border border-rose-400/35 bg-rose-400/15 px-4 py-2 text-sm text-rose-200 transition hover:bg-rose-400/25 disabled:cursor-wait disabled:opacity-50"
+											disabled={actionState[session.clientIdentifier] != null}
+											onclick={() => sendCommand(session.clientIdentifier, 'Shutdown')}
+										>
+											Shutdown
+										</button>
+									</div>
+								</div>
+							</div>
+
+							<div class="flex flex-col gap-4 px-5 py-5 sm:px-6">
+								<section class="min-w-0 rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5">
+									<div class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+										<h3 class="min-w-0 text-lg font-semibold">Current Media</h3>
+										{#if session.currentDisplay}
+											<span class="max-w-full text-xs uppercase tracking-[0.3em] text-stone-400 sm:shrink-0">
+												{formatDateTime(session.currentDisplay.displayedAtUtc)}
+											</span>
+										{/if}
+									</div>
+
+									{#if getCurrentAssets(session).length === 0}
+										<p class="mt-4 text-sm text-stone-400">No media currently reported.</p>
+									{:else}
+										<div class="mt-4 space-y-3">
+											{#each getCurrentAssets(session) as asset}
+												{@const assetUrl = getAssetUrl(asset)}
+												{#if assetUrl}
+													<a
+														class="block min-w-0 rounded-2xl border border-white/8 transition-[background-image,border-color] duration-200 ease-linear hover:border-[color:var(--primary-color)]/55"
+														style={getCurrentMediaCardStyle(session)}
+														href={assetUrl}
+														target="_blank"
+														rel="noreferrer"
+													>
+														<div class="px-4 py-3">
+															<div class="flex min-w-0 flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+																<p class="min-w-0 break-words font-medium text-stone-100">
+																	{asset.originalFileName}
+																</p>
+																<span class="shrink-0 text-xs uppercase tracking-[0.2em] text-stone-300">
+																	{formatAssetType(asset.type)}
+																</span>
+															</div>
+															{#if asset.localDateTime}
+																<p class="mt-1 text-sm text-stone-300">
+																	Taken {formatDateTime(asset.localDateTime)}
+																</p>
+															{/if}
+															{#if asset.description}
+																<p class="mt-2 break-words text-sm text-stone-200">{asset.description}</p>
+															{/if}
+														</div>
+													</a>
+												{:else}
+													<div
+														class="min-w-0 rounded-2xl border border-white/8 transition-[background-image] duration-200 ease-linear"
+														style={getCurrentMediaCardStyle(session)}
+													>
+														<div class="px-4 py-3">
+															<div class="flex min-w-0 flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+																<p class="min-w-0 break-words font-medium text-stone-100">
+																	{asset.originalFileName}
+																</p>
+																<span class="shrink-0 text-xs uppercase tracking-[0.2em] text-stone-300">
+																	{formatAssetType(asset.type)}
+																</span>
+															</div>
+															{#if asset.localDateTime}
+																<p class="mt-1 text-sm text-stone-300">
+																	Taken {formatDateTime(asset.localDateTime)}
+																</p>
+															{/if}
+															{#if asset.description}
+																<p class="mt-2 break-words text-sm text-stone-200">{asset.description}</p>
+															{/if}
+														</div>
+													</div>
+												{/if}
+											{/each}
+										</div>
+									{/if}
+								</section>
+
+								<section class="min-w-0 rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5">
+									<div class="flex items-center justify-between gap-3">
+										<h3 class="text-lg font-semibold">Recent History</h3>
+										<span class="shrink-0 text-xs uppercase tracking-[0.3em] text-stone-400">
+											{getHistory(session).length} events
+										</span>
+									</div>
+
+									{#if getHistory(session).length === 0}
+										<p class="mt-4 text-sm text-stone-400">No previous media has been reported yet.</p>
+									{:else}
+										<div
+											class="mt-4 space-y-3"
+											class:max-h-[18rem]={getHistory(session).length > 3}
+											class:overflow-y-auto={getHistory(session).length > 3}
+											class:pr-1={getHistory(session).length > 3}
+										>
+											{#each getHistory(session) as event, index (event.displayedAtUtc + index)}
+												<div class="min-w-0 rounded-2xl border border-white/8 bg-black/25 px-4 py-3">
+													<div class="flex items-center justify-between gap-3">
+														<p class="min-w-0 truncate text-xs uppercase tracking-[0.25em] text-stone-400">
+															{formatDateTime(event.displayedAtUtc)}
+														</p>
+														<span class="shrink-0 text-xs text-stone-500">
+															{event.assets.length} item{event.assets.length === 1 ? '' : 's'}
+														</span>
+													</div>
+													<div class="mt-3 flex flex-wrap gap-2">
+														{#each event.assets as asset}
+															{@const assetUrl = getAssetUrl(asset)}
+															{#if assetUrl}
+																<a
+																	class="max-w-full break-all rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sm text-stone-200 transition hover:border-[color:var(--primary-color)]/50 hover:bg-white/10"
+																	href={assetUrl}
+																	target="_blank"
+																	rel="noreferrer"
+																>
+																	{asset.originalFileName}
+																</a>
+															{:else}
+																<span
+																	class="max-w-full break-all rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sm text-stone-200"
+																>
+																	{asset.originalFileName}
+																</span>
+															{/if}
+														{/each}
+													</div>
+												</div>
+											{/each}
+										</div>
+									{/if}
+								</section>
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</section>
+{/if}


### PR DESCRIPTION
I've added an admin page accessible through http:{ImmichFrameURL}/admin.
<img width="1910" height="1147" alt="2026-03-28_16-31-12" src="https://github.com/user-attachments/assets/eec9c9db-8ec8-4409-94f2-db2813fc2b39" />
<img width="1908" height="624" alt="2026-03-28_16-34-43" src="https://github.com/user-attachments/assets/9aa287df-260a-4a98-b351-53ec7b008c86" />

The purpose of this page is to provide the ability to manage frames remotely. An admin can view any active session, change the media displayed (previous, play/pause, next), refresh or shutdown the session altogether. The currently displayed media can be viewed along with an history or recently displayed media which when clicked, opens the corresponding media page on the user's immich server to further manage. Frame are initially named by ID (Frame-ID), but users can rename frame. An app-data directory must be mounted as volume to allow for the frame naming to persist through app rebuild and docker container recreation .

The admin page is protected by basic browser authentication and an Htpasswd compliant hash. To enable the admin login page, add at least one matching `IMMICHFRAME_AUTH_BASIC_*_USER` and `IMMICHFRAME_AUTH_BASIC_*_HASH` pair to your environment or `.env` file. These env values remain the source of truth for admin users, and the `/admin` page signs in against them with a normal session cookie. If these variables aren't declared, immichframe works as usual, but /admin is inaccessible.

I understand this is a comically large pull request and honestly, this was entirely vibe coded in a couple days, so I completely understand the reservation in implementing this into the main project branch. Think of this as just an idea of what could be. I do think it would be neat to have the ability to manage frames without having to SSH into servers and tinker with .env files and container recreation. I would love to see this admin page evolve in a manner where the .env file would only contain the required configurations for ImmichFrame to run (ImmichServerUrl + ApiKey + AdminAuth) while all other variables would be configured live within the UI through the admin page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard for live monitoring/control; admin login, enqueue remote commands, edit display names
  * Frame client: heartbeat, snapshot sync, command polling/acknowledge, graceful disconnect (beacon support)
  * Admin and frame APIs for session and command management; session registry with persistence and pruning

* **Bug Fixes**
  * Improved null-safety, guard clauses, and stale-session handling

* **Documentation**
  * Install guide documents UI/admin on port 8080 and admin login setup

* **Chores**
  * Docker runtime aligned to port 8080; added bcrypt dependency; many new tests for auth and session flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->