### PR TITLE
Fix freeze caused by progress bar firing onDone during asset transitions

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/asset.svelte
+++ b/immichFrame.Web/src/lib/components/elements/asset.svelte
@@ -9,6 +9,7 @@
 	import { thumbHashToDataURL } from 'thumbhash';
 	import AssetInfo from '$lib/components/elements/asset-info.svelte';
 	import ImageOverlay from '$lib/components/elements/imageoverlay/image-overlay.svelte';
+	import { onDestroy } from 'svelte';
 
 	interface Props {
 		asset: [url: string, asset: AssetResponseDto, albums: AlbumResponseDto[]];
@@ -184,6 +185,18 @@
 			}
 		}
 	};
+
+	let isDestroyed = false;
+
+	onDestroy(() => {
+		isDestroyed = true;
+		if (videoElement) {
+			videoElement.pause();
+			videoElement.src = '';
+			videoElement.removeAttribute('src');
+			videoElement.load();
+		}
+	});
 </script>
 
 {#if showInfo}
@@ -246,9 +259,12 @@
 						}
 					}
 				}}
-				onerror={() => console.error('Video failed to load:', asset[0])}
-				onwaiting={onVideoWaiting}
-				onplaying={onVideoPlaying}
+				onwaiting={() => {
+					if (!isDestroyed) onVideoWaiting();
+				}}
+				onplaying={() => {
+					if (!isDestroyed) onVideoPlaying();
+				}}
 			></video>
 		{:else}
 			<img

--- a/immichFrame.Web/src/lib/components/elements/progress-bar.svelte
+++ b/immichFrame.Web/src/lib/components/elements/progress-bar.svelte
@@ -28,7 +28,9 @@
 
 	const onChange = async (progressDuration: number) => {
 		progress = setDuration(progressDuration);
-		await play();
+		if (status === ProgressBarStatus.Playing) {
+			await play();
+		}
 	};
 
 	let progress = setDuration(duration);

--- a/immichFrame.Web/src/lib/components/elements/progress-bar.svelte
+++ b/immichFrame.Web/src/lib/components/elements/progress-bar.svelte
@@ -28,9 +28,7 @@
 
 	const onChange = async (progressDuration: number) => {
 		progress = setDuration(progressDuration);
-		if (status === ProgressBarStatus.Playing) {
-			await play();
-		}
+		await play();
 	};
 
 	let progress = setDuration(duration);

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -149,24 +149,24 @@
 		}
 	}
 
-	let isHandlingAssetTransition = false;
+	let transitionLock: Promise<void> = Promise.resolve();
+
 	const handleDone = async (previous: boolean = false, instant: boolean = false) => {
-		if (isHandlingAssetTransition) {
-			return;
-		}
-		isHandlingAssetTransition = true;
-		try {
-			userPaused = false;
-			progressBar.restart(false);
-			$instantTransition = instant;
-			if (previous) await getPreviousAssets();
-			else await getNextAssets();
-			await tick();
-			await assetComponent?.play?.();
-			progressBar.play();
-		} finally {
-			isHandlingAssetTransition = false;
-		}
+		transitionLock = transitionLock
+			.then(async () => {
+				userPaused = false;
+				progressBar.restart(false);
+				$instantTransition = instant;
+				if (previous) await getPreviousAssets();
+				else await getNextAssets();
+				await tick();
+				await assetComponent?.play?.();
+				progressBar.play();
+			})
+			.catch((err) => {
+				console.error('handleDone transition failed:', err);
+			});
+		await transitionLock;
 	};
 
 	async function getNextAssets() {


### PR DESCRIPTION
The progress bar's onChange handler was unconditionally calling play()
whenever the duration changed, causing onDone to fire multiple times
in rapid succession during asset transitions. This created a race
condition that caused a freeze.

Fixed by only calling play() in onChange when the progress bar is
already in a playing state. Also replaced the boolean
isHandlingAssetTransition guard with a promise-based transitionLock
to safely serialize any concurrent handleDone calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset transition reliability by ensuring all transition operations execute in the correct sequence without interruption from concurrent requests.
  * Enhanced cleanup of video elements when components are destroyed to prevent playback issues and memory leaks.
  * Fixed event handlers from invoking after component destruction to prevent unexpected behavior and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->